### PR TITLE
test_lockf: wait for child before unlinking test file

### DIFF
--- a/src/posix/tests/test_lockf.c
+++ b/src/posix/tests/test_lockf.c
@@ -428,9 +428,16 @@ main(
     send_sig(p2c[1]); /* tell child lock is released */
 
     chimera_posix_close(fd);
-    chimera_posix_unlink(TEST_FILE);
 
+    /*
+     * Wait for child to finish its post-unlock F_TEST/F_TLOCK/F_ULOCK
+     * sequence before unlinking. Otherwise the unlink races with the
+     * child's NLM LOCK, which opens the file by fh on the server and
+     * fails with NLM4_STALE_FH once the file has been removed.
+     */
     waitpid(child, &status, 0);
+
+    chimera_posix_unlink(TEST_FILE);
 
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
         if (WIFEXITED(status) && WEXITSTATUS(status) == 2) {


### PR DESCRIPTION
## Summary

Fixes a periodic `chimera/posix/lockf_nfs3_io_uring` CI failure:

```
child: F_TLOCK after unlock failed: Stale file handle
```

The parent in `test_lockf.c` was unlinking `lockf_test` immediately after signalling the child that its lock had been released, while the child was still running its post-unlock `F_TEST` / `F_TLOCK` / `F_ULOCK` sequence. The NLM `LOCK` path on the server opens the file by fh, so once the `Remove` landed the child's `F_TLOCK` came back with `NLM4_STALE_FH` and the test failed.

Move the `chimera_posix_unlink(TEST_FILE)` call to after `waitpid()` so the child finishes (and closes its fd) before the file is removed.

Verified locally by running `chimera/posix/lockf_nfs3_io_uring` 30 times in a row (all pass), plus all 14 `posix/(lockf|fcntl)` tests.