### PR TITLE
vfs: add sync_delegation config toggle (default enabled)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Chimera uses JSON configuration files. Example:
         }
     },
     "core_threads": 4,
+    "sync_delegation": true,
     "sync_delegation_threads": 16,
     "async_delegation": false,
     "async_delegation_threads": 8,

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -26,6 +26,7 @@ chimera_client_config_init(void)
     config = calloc(1, sizeof(struct chimera_client_config));
 
     config->core_threads             = 16;
+    config->sync_delegation          = 1;
     config->sync_delegation_threads  = 64;
     config->async_delegation         = 0;
     config->async_delegation_threads = 8;
@@ -141,7 +142,7 @@ chimera_client_init(
 
     chimera_client_info("Initializing VFS...");
 
-    client->vfs = chimera_vfs_init(config->sync_delegation_threads,
+    client->vfs = chimera_vfs_init(config->sync_delegation ? config->sync_delegation_threads : 0,
                                    config->async_delegation ? config->async_delegation_threads : 0,
                                    config->modules,
                                    config->num_modules,
@@ -205,6 +206,11 @@ chimera_client_init_json(
         val = json_object_get(config_section, "core_threads");
         if (val && json_is_integer(val)) {
             config->core_threads = json_integer_value(val);
+        }
+
+        val = json_object_get(config_section, "sync_delegation");
+        if (val && json_is_boolean(val)) {
+            config->sync_delegation = json_is_true(val);
         }
 
         val = json_object_get(config_section, "sync_delegation_threads");

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -358,6 +358,7 @@ struct chimera_client_request {
 
 struct chimera_client_config {
     int                           core_threads;
+    int                           sync_delegation;
     int                           sync_delegation_threads;
     int                           async_delegation;
     int                           async_delegation_threads;

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -1,6 +1,7 @@
 {
     "server": {
 	"threads": 16,
+	"sync_delegation": true,
 	"sync_delegation_threads": 1,
 	"async_delegation": false,
 	"async_delegation_threads": 8

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -337,6 +337,11 @@ main(
         chimera_server_config_set_max_open_files(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "sync_delegation");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_sync_delegation(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "sync_delegation_threads");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -46,6 +46,7 @@ struct chimera_server_config {
     int                                   soft_fail_bad_req;
     rlim_t                                max_open_files;
     int                                   core_threads;
+    int                                   sync_delegation;
     int                                   sync_delegation_threads;
     int                                   async_delegation;
     int                                   async_delegation_threads;
@@ -103,6 +104,7 @@ chimera_server_config_init(void)
 
     config->core_threads             = 8;
     config->max_open_files           = 65535;
+    config->sync_delegation          = 1;
     config->sync_delegation_threads  = 8;
     config->async_delegation         = 0;
     config->async_delegation_threads = 8;
@@ -172,6 +174,14 @@ chimera_server_config_set_core_threads(
 {
     config->core_threads = threads;
 } /* chimera_server_config_set_core_threads */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_sync_delegation(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->sync_delegation = enable;
+} /* chimera_server_config_set_sync_delegation */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_sync_delegation_threads(
@@ -785,7 +795,7 @@ chimera_server_init(
     pthread_cond_init(&server->all_threads_online, NULL);
 
     chimera_server_info("Initializing VFS...");
-    server->vfs = chimera_vfs_init(config->sync_delegation_threads,
+    server->vfs = chimera_vfs_init(config->sync_delegation ? config->sync_delegation_threads : 0,
                                    config->async_delegation ? config->async_delegation_threads : 0,
                                    config->modules,
                                    config->num_modules,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -61,6 +61,11 @@ chimera_server_config_set_core_threads(
     int                           threads);
 
 void
+chimera_server_config_set_sync_delegation(
+    struct chimera_server_config *config,
+    int                           enable);
+
+void
 chimera_server_config_set_sync_delegation_threads(
     struct chimera_server_config *config,
     int                           threads);

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ add_executable(vfs_async_delegation_test vfs_async_delegation_test.c)
 target_link_libraries(vfs_async_delegation_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/async_delegation_test vfs_async_delegation_test)
 
+add_executable(vfs_sync_delegation_test vfs_sync_delegation_test.c)
+target_link_libraries(vfs_sync_delegation_test chimera_vfs chimera_vfs_cairn evpl)
+add_test(chimera/vfs/sync_delegation_test vfs_sync_delegation_test)
+
 add_executable(vfs_notify_test vfs_notify_test.c)
 target_link_libraries(vfs_notify_test chimera_vfs urcu)
 add_test(chimera/vfs/notify_test vfs_notify_test)

--- a/src/vfs/tests/vfs_sync_delegation_test.c
+++ b/src/vfs/tests/vfs_sync_delegation_test.c
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Exercises the sync delegation thread pool with a BLOCKING backend (cairn).
+ * Verifies:
+ *   - With the pool enabled, BLOCKING module dispatch is routed to a sync
+ *     delegation thread (off the caller thread) with FH-hash affinity.
+ *   - With the pool disabled (count = 0), the BLOCKING capability is ignored
+ *     and dispatch falls back to inline execution on the caller thread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define NUM_SYNC_THREADS  4
+#define NUM_DISTINCT_KEYS 32
+
+struct test_ctx {
+    int                        done;
+    enum chimera_vfs_error status;
+    int                        search_hits;
+    pthread_t                  dispatch_tid;
+    struct chimera_vfs        *vfs;
+    struct chimera_vfs_thread *vfs_thread;
+    struct evpl               *evpl;
+};
+
+static void
+put_key_callback(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* put_key_callback */
+
+static void
+delete_key_callback(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* delete_key_callback */
+
+/*
+ * The per-entry callback runs inside the module's dispatch routine, which
+ * executes on the thread that picked the request up. With sync delegation
+ * enabled, a BLOCKING module runs on a sync delegation thread; with it
+ * disabled, the BLOCKING flag is ignored and dispatch runs on the caller.
+ */
+static int
+search_keys_callback(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->dispatch_tid = pthread_self();
+    ctx->search_hits++;
+    return 0;
+} /* search_keys_callback */
+
+static void
+search_keys_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* search_keys_complete */
+
+static void
+wait_for_completion(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_for_completion */
+
+static void
+put_key(
+    struct test_ctx *ctx,
+    const char      *key,
+    const char      *value)
+{
+    ctx->search_hits = 0;
+    chimera_vfs_put_key(
+        ctx->vfs_thread,
+        key,
+        strlen(key),
+        value,
+        strlen(value),
+        put_key_callback,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* put_key */
+
+/*
+ * Runs a search over a range that matches a single inserted key and returns
+ * the pthread_t that ran the per-entry callback.
+ */
+static pthread_t
+search_for_single_key(
+    struct test_ctx *ctx,
+    const char      *key)
+{
+    ctx->search_hits  = 0;
+    ctx->dispatch_tid = 0;
+
+    /* Inclusive range [key, key]: cairn iterates the KV keyspace from the
+     * start key and stops once a key sorts past the end key, so an end key
+     * equal to the start key matches exactly the one stored entry. */
+    chimera_vfs_search_keys(
+        ctx->vfs_thread,
+        key,
+        strlen(key),
+        key,
+        strlen(key),
+        search_keys_callback,
+        search_keys_complete,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->search_hits == 1);
+    assert(ctx->dispatch_tid != 0);
+
+    return ctx->dispatch_tid;
+} /* search_for_single_key */
+
+static void
+delete_keys(
+    struct test_ctx *ctx,
+    char             keys[][32],
+    int              count)
+{
+    int i;
+
+    for (i = 0; i < count; i++) {
+        chimera_vfs_delete_key(
+            ctx->vfs_thread,
+            keys[i],
+            strlen(keys[i]),
+            delete_key_callback,
+            ctx);
+        wait_for_completion(ctx);
+        assert(ctx->status == CHIMERA_VFS_OK);
+    }
+} /* delete_keys */
+
+static void
+test_sync_delegation_enabled(struct test_ctx *ctx)
+{
+    pthread_t main_tid = pthread_self();
+    pthread_t tids[NUM_DISTINCT_KEYS];
+    char      keys[NUM_DISTINCT_KEYS][32];
+    char      values[NUM_DISTINCT_KEYS][32];
+    int       i, j;
+    int       distinct_threads = 0;
+    int       saw_main_thread  = 0;
+
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        snprintf(keys[i], sizeof(keys[i]), "sync_test_%02d", i);
+        snprintf(values[i], sizeof(values[i]), "v_%02d", i);
+        put_key(ctx, keys[i], values[i]);
+    }
+
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        tids[i] = search_for_single_key(ctx, keys[i]);
+        if (pthread_equal(tids[i], main_tid)) {
+            saw_main_thread = 1;
+        }
+    }
+
+    /* A BLOCKING backend with the sync pool enabled must never dispatch on
+     * the caller thread. */
+    assert(saw_main_thread == 0);
+
+    /* Affinity: re-running search for the same key lands on the same thread. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        pthread_t again = search_for_single_key(ctx, keys[i]);
+        assert(pthread_equal(again, tids[i]));
+    }
+
+    /* Distribution: 4 threads, 32 independently hashed keys -> multiple used. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        int seen = 0;
+        for (j = 0; j < i; j++) {
+            if (pthread_equal(tids[i], tids[j])) {
+                seen = 1;
+                break;
+            }
+        }
+        if (!seen) {
+            distinct_threads++;
+        }
+    }
+    assert(distinct_threads >= 2);
+
+    delete_keys(ctx, keys, NUM_DISTINCT_KEYS);
+
+    fprintf(stderr, "    %d distinct dispatch threads used across %d keys\n",
+            distinct_threads, NUM_DISTINCT_KEYS);
+    TEST_PASS("sync delegation routes BLOCKING dispatch off the caller thread with FH-hash affinity");
+} /* test_sync_delegation_enabled */
+
+static void
+test_sync_delegation_disabled(struct test_ctx *ctx)
+{
+    pthread_t main_tid = pthread_self();
+    pthread_t tid;
+    char      keys[1][32];
+
+    snprintf(keys[0], sizeof(keys[0]), "inline_key_a");
+    put_key(ctx, keys[0], "v_a");
+
+    tid = search_for_single_key(ctx, keys[0]);
+
+    /* With the sync pool disabled, the BLOCKING flag is ignored and dispatch
+     * must happen inline on the caller thread. */
+    assert(pthread_equal(tid, main_tid));
+
+    delete_keys(ctx, keys, 1);
+
+    TEST_PASS("sync delegation disabled ignores BLOCKING and routes dispatch inline");
+} /* test_sync_delegation_disabled */
+
+static void
+run_phase(
+    int         num_sync_threads,
+    const char *label,
+    void (     *test_fn )(struct test_ctx *))
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs_module_cfg module_cfgs[1];
+    struct prometheus_metrics    *metrics;
+    char                          tmpl[]    = "/tmp/chimera_sync_deleg_XXXXXX";
+    char                         *cairn_dir = mkdtemp(tmpl);
+    char                          cairn_cfg[256];
+    char                          rmcmd[512];
+
+    assert(cairn_dir != NULL);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "cairn", sizeof(module_cfgs[0].module_name) - 1);
+    snprintf(cairn_cfg, sizeof(cairn_cfg),
+             "{\"initialize\":true,\"path\":\"%s\"}", cairn_dir);
+    strncpy(module_cfgs[0].config_data, cairn_cfg, sizeof(module_cfgs[0].config_data) - 1);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(
+        num_sync_threads,  /* num_sync_delegation_threads */
+        0,                 /* num_async_delegation_threads */
+        module_cfgs,
+        1,
+        "cairn",
+        60,
+        metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    fprintf(stderr, "Phase: %s (num_sync_delegation_threads=%d)\n",
+            label, num_sync_threads);
+
+    test_fn(&ctx);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    snprintf(rmcmd, sizeof(rmcmd), "rm -rf %s", cairn_dir);
+    if (system(rmcmd) != 0) {
+        fprintf(stderr, "warning: failed to remove %s\n", cairn_dir);
+    }
+} /* run_phase */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    chimera_log_init();
+
+    run_phase(NUM_SYNC_THREADS, "sync delegation enabled",
+              test_sync_delegation_enabled);
+    run_phase(0, "sync delegation disabled",
+              test_sync_delegation_disabled);
+
+    fprintf(stderr, "All sync delegation tests passed!\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -381,7 +381,8 @@ chimera_vfs_dispatch(struct chimera_vfs_request *request)
         return;
     }
 
-    if (module->capabilities & CHIMERA_VFS_CAP_BLOCKING) {
+    if ((module->capabilities & CHIMERA_VFS_CAP_BLOCKING) &&
+        vfs->num_sync_delegation_threads > 0) {
         thread_id         = request->fh_hash % vfs->num_sync_delegation_threads;
         delegation_thread = &vfs->sync_delegation_threads[thread_id];
         chimera_vfs_post_to_delegation(request, delegation_thread);

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -380,6 +380,7 @@ chimera_vfs_notify_resolve(struct chimera_vfs_notify_pending_event *pev)
     struct chimera_vfs_notify             *notify = pev->notify;
     struct chimera_vfs_notify_mount_entry *me;
     struct chimera_vfs_notify_watch       *watch;
+    struct chimera_vfs_thread             *worker_thread;
     uint8_t                                r_parent_fh[CHIMERA_VFS_FH_SIZE];
     uint16_t                               r_parent_fh_len;
     char                                   r_name[CHIMERA_VFS_NAME_MAX];
@@ -485,8 +486,14 @@ chimera_vfs_notify_resolve(struct chimera_vfs_notify_pending_event *pev)
         }
 
         /* Cache miss — issue async getparent.
-         * The callback will continue the resolve loop. */
-        chimera_vfs_getparent(notify->vfs->sync_delegation_threads[0].vfs_thread,
+         * The callback will continue the resolve loop.  Run it on the first
+         * sync delegation thread when available, otherwise fall back to the
+         * always-present close thread (the sync pool may be disabled). */
+        worker_thread = notify->vfs->num_sync_delegation_threads > 0 ?
+            notify->vfs->sync_delegation_threads[0].vfs_thread :
+            notify->vfs->close_thread.vfs_thread;
+
+        chimera_vfs_getparent(worker_thread,
                               NULL, /* cred — internal operation */
                               pev->walk_fh,
                               pev->walk_fh_len,

--- a/src/vfs/vfs_proc_readdir.c
+++ b/src/vfs/vfs_proc_readdir.c
@@ -147,10 +147,15 @@ chimera_vfs_readdir(
     request->readdir.orig_callback = NULL;
 
     /* If this module is blocking then we need to bounce the results into the original thread
-     * before making the caller provided result callback
+     * before making the caller provided result callback.  This only applies when the request
+     * will actually be dispatched to a delegation thread; if the sync delegation pool is
+     * disabled and there is no async pool, the blocking module runs inline on this thread and
+     * its result callback can safely target the original buffers directly.
      */
 
-    if (module->capabilities & CHIMERA_VFS_CAP_BLOCKING) {
+    if ((module->capabilities & CHIMERA_VFS_CAP_BLOCKING) &&
+        (thread->vfs->num_sync_delegation_threads > 0 ||
+         thread->vfs->num_async_delegation_threads > 0)) {
 
         evpl_iovec_alloc(thread->evpl, 64 * 1024, 8, 1, 0, &request->readdir.bounce_iov);
 


### PR DESCRIPTION
## Summary

Adds a `sync_delegation` config boolean (default **enabled**) that toggles the sync delegation thread pool, mirroring the existing `async_delegation` flag. Previously the sync pool was unconditionally started. When disabled, the pool is never started/stopped and the `CHIMERA_VFS_CAP_BLOCKING` capability is ignored — blocking backends are dispatched inline as though non-blocking.

## Changes

**Config plumbing** (server + client, both default to enabled):
- `server.c`/`server.h`: new `sync_delegation` struct field, default `= 1`, and `chimera_server_config_set_sync_delegation()` setter.
- `daemon.c`: parses `"sync_delegation"` from the server JSON section.
- `client.c`/`client_internal.h`: matching field, default, and JSON parsing.
- Both `chimera_vfs_init()` call sites pass `sync_delegation ? sync_delegation_threads : 0`. A count of `0` already cleanly skips pool spawn and teardown.

**Behavioral fixes for the disabled path:**
- `vfs_internal.h`: `chimera_vfs_dispatch()` routes a BLOCKING module to the sync pool only when `num_sync_delegation_threads > 0`; otherwise it falls through to the async pool or inline execution.
- `vfs_proc_readdir.c`: the result-bounce (needed only when a blocking module runs on a foreign delegation thread) is skipped when the request runs inline, and still applied when an async pool would pick it up.
- `vfs_notify.c`: the resolver hard-indexed `sync_delegation_threads[0]`, which would dereference NULL when the pool is empty; it now falls back to the always-present close thread.

**Docs/examples:** `chimera.json` and `CLAUDE.md` config examples show `sync_delegation`.

**Test:** `vfs_sync_delegation_test.c` (modeled on the async test) uses the blocking cairn KV backend to verify dispatch runs off the caller thread with FH-hash affinity when enabled, and inline on the caller thread when disabled.

## Verification
- `make syntax-check` and `make reuse-lint` pass.
- Full release suite: 2397/2397 passed.
- ASan debug build, delegation/notify/readdir/cairn/kv subset: 366/366 passed.