### PR TITLE
SMB3 durable/persistent file handles (initial, in-memory)

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -359,6 +359,11 @@ main(
         chimera_server_config_set_async_delegation_threads(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "smb_persistent_handles");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "nfs4_session_slots");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -58,6 +58,7 @@ struct chimera_server_config {
     int                                   rest_https_port;
     int                                   smb_num_dialects;
     uint32_t                              smb_dialects[16];
+    int                                   smb_persistent_handles;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -120,6 +121,10 @@ chimera_server_config_init(void)
     config->smb_dialects[1]  = SMB2_DIALECT_3_0;
 
     config->smb_num_nic_info = 0;
+
+    /* SMB3 durable/persistent handles are off by default; they are an
+     * opt-in feature gated by the "smb_persistent_handles" config flag. */
+    config->smb_persistent_handles = 0;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -212,6 +217,20 @@ chimera_server_config_set_async_delegation_threads(
 {
     config->async_delegation_threads = threads;
 } /* chimera_server_config_set_async_delegation_threads */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_persistent_handles(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->smb_persistent_handles = enable;
+} /* chimera_server_config_set_smb_persistent_handles */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_persistent_handles(const struct chimera_server_config *config)
+{
+    return config->smb_persistent_handles;
+} /* chimera_server_config_get_smb_persistent_handles */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -81,6 +81,15 @@ chimera_server_config_set_async_delegation_threads(
     int                           threads);
 
 void
+chimera_server_config_set_smb_persistent_handles(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_smb_persistent_handles(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(chimera_smb SHARED
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c
     smb_proc_lock.c smb_proc_oplock_break.c
-    smb_notify.c smb_sharemode.c smb_ntlm.c
+    smb_notify.c smb_sharemode.c smb_ntlm.c smb_durable.c
     smb_wbclient.c smb_auth.c smb_gssapi.c
     #idl/ndr_dcerpc.c
 )

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -143,7 +143,12 @@ chimera_smb_server_init(
                          shared->config.auth.kerberos_keytab[0] ? shared->config.auth.kerberos_keytab : "(default)");
     }
 
-    shared->config.soft_fail_bad_req = chimera_server_config_get_soft_fail_bad_req(config);
+    shared->config.soft_fail_bad_req  = chimera_server_config_get_soft_fail_bad_req(config);
+    shared->config.persistent_handles = chimera_server_config_get_smb_persistent_handles(config);
+
+    if (shared->config.persistent_handles) {
+        chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
+    }
 
     shared->vfs     = vfs;
     shared->metrics = metrics;
@@ -174,6 +179,13 @@ chimera_smb_server_init(
     pthread_mutex_init(&shared->shares_lock, NULL);
     pthread_mutex_init(&shared->trees_lock, NULL);
 
+    /* Seed the persistent-id allocator with a random, nonzero base so ids do
+     * not restart from a fixed value across daemon restarts (a courtesy to the
+     * future on-disk persistence layer; 0 is reserved for "no file id"). */
+    atomic_init(&shared->next_persistent_id, (chimera_rand64() | 1));
+
+    chimera_smb_durable_table_init(&shared->durable);
+
     return shared;
 } /* smb_server_init */
 
@@ -195,6 +207,8 @@ chimera_smb_server_destroy(void *data)
 
 
     chimera_smb_abort_if(shared->sessions, "active sessions exist at server shutdown")
+
+    chimera_smb_durable_table_destroy(&shared->durable);
 
     while (shared->free_sessions) {
         session = shared->free_sessions;
@@ -1334,6 +1348,20 @@ chimera_smb_server_accept(
 } /* smb_server_accept */
 
 
+/* Interval between durable-handle reconnect-grace sweeps. */
+#define CHIMERA_SMB_DURABLE_SWEEP_INTERVAL_US (1 * 1000 * 1000)
+
+static void
+chimera_smb_durable_sweeper_fire(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_server_smb_thread *thread =
+        container_of(timer, struct chimera_server_smb_thread, durable_sweeper);
+
+    chimera_smb_durable_sweep(thread);
+} /* chimera_smb_durable_sweeper_fire */
+
 static void *
 chimera_smb_server_thread_init(
     struct evpl               *evpl,
@@ -1354,6 +1382,12 @@ chimera_smb_server_thread_init(
 
     chimera_smb_iconv_init(&thread->iconv_ctx);
     chimera_smb_notify_thread_init(thread);
+
+    if (shared->config.persistent_handles) {
+        evpl_add_timer(evpl, &thread->durable_sweeper,
+                       chimera_smb_durable_sweeper_fire,
+                       CHIMERA_SMB_DURABLE_SWEEP_INTERVAL_US);
+    }
 
     thread->binding = evpl_listener_attach(
         evpl,
@@ -1404,6 +1438,10 @@ chimera_smb_server_thread_destroy(void *data)
         free(session_handle);
     }
 
+    if (thread->shared->config.persistent_handles) {
+        evpl_remove_timer(thread->evpl, &thread->durable_sweeper);
+    }
+
     evpl_listener_detach(thread->evpl, thread->binding);
     chimera_smb_notify_thread_destroy(thread);
 
@@ -1426,6 +1464,11 @@ chimera_smb_add_share(
     snprintf(share->name, sizeof(share->name), "%s", name);
     snprintf(share->path, sizeof(share->path), "%s", path);
     chimera_smb_sharemode_init(&share->sharemode);
+
+    /* Initial pass: every share inherits continuous-availability from the
+     * global persistent-handles flag.  A per-share config knob will refine
+     * this later. */
+    share->continuous_availability = shared->config.persistent_handles;
 
     pthread_mutex_lock(&shared->shares_lock);
     LL_PREPEND(shared->shares, share);

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -541,6 +541,7 @@
 #define SMB2_STATUS_VOLUME_DISMOUNTED                 0xC000026E
 #define SMB2_STATUS_NOT_A_REPARSE_POINT               0xC0000275
 #define SMB2_STATUS_SERVER_UNAVAILABLE                0xC0000466
+#define SMB2_STATUS_FILE_NOT_AVAILABLE                0xC0000467
 
 /* Warning codes */
 #define SMB2_STATUS_BUFFER_OVERFLOW                   0x80000005
@@ -608,6 +609,16 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_GLOBAL_CAP_PERSISTENT_HANDLES          0x00000010 // Supports persistent handles (SMB 3.0+)
 #define SMB2_GLOBAL_CAP_DIRECTORY_LEASING           0x00000020 // Supports directory leasing (SMB 3.0+)
 #define SMB2_GLOBAL_CAP_ENCRYPTION                  0x00000040 // Supports encryption (SMB 3.0+)
+
+// SMB2 TREE_CONNECT response share capabilities (MS-SMB2 §2.2.10)
+#define SMB2_SHARE_CAP_DFS                          0x00000008
+#define SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY      0x00000010 // CA share (persistent handles)
+#define SMB2_SHARE_CAP_SCALEOUT                     0x00000020
+#define SMB2_SHARE_CAP_CLUSTER                      0x00000040
+#define SMB2_SHARE_CAP_ASYMMETRIC                   0x00000080
+
+// SMB2 CREATE durable-handle-request-v2 (DH2Q) / response flags (MS-SMB2 §2.2.13.2.11)
+#define SMB2_DHANDLE_FLAG_PERSISTENT                0x00000002
 
 /* SMB2 3.1.1 negotiate context types (MS-SMB2 §2.2.3.1) */
 #define SMB2_PREAUTH_INTEGRITY_CAPABILITIES         0x0001

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * In-memory durable/persistent SMB3 handle registry.
+ *
+ * This is the initial, memory-only implementation: a durable open survives the
+ * teardown of its owning connection by remaining allocated and being indexed
+ * here, keyed by its (globally unique) persistent id.  A reconnect within the
+ * grace window re-homes the surviving open into the new tree; otherwise the
+ * per-thread sweeper reaps it.
+ *
+ * Ownership / refcount invariant:
+ *   - A durable open is registered live (parked == false) at CREATE grant and
+ *     forgotten when it is finally destroyed (normal close or reap).
+ *   - While live it sits in a tree's open_files[] hash with the usual refcount
+ *     (1 == tree membership).  The registry holds only a weak pointer and never
+ *     dereferences a non-parked entry's open_file.
+ *   - At disconnect the open is removed from its tree but NOT freed; the
+ *     registry's reference becomes its sole owner (refcnt stays 1, PARKED set).
+ *   - A reconnect re-homes it (PARKED cleared); the sweeper frees it.
+ *
+ * Locking: the registry lock is a leaf taken either alone (register / claim /
+ * sweep-collect) or nested INSIDE a tree bucket lock (park / forget).  No path
+ * acquires a bucket lock while holding the registry lock, and the heavyweight
+ * VFS teardown in the sweeper runs after the registry lock is dropped, so the
+ * global order bucket -> registry -> vfs_state holds with no inversion.
+ */
+
+#include "smb_internal.h"
+#include "common/misc.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_release.h"
+
+SYMBOL_EXPORT void
+chimera_smb_durable_table_init(struct chimera_smb_durable_table *table)
+{
+    pthread_mutex_init(&table->lock, NULL);
+    table->by_pid = NULL;
+} /* chimera_smb_durable_table_init */
+
+SYMBOL_EXPORT void
+chimera_smb_durable_table_destroy(struct chimera_smb_durable_table *table)
+{
+    struct chimera_smb_durable_entry *entry, *tmp;
+
+    /* By the time the server is destroyed all sessions are gone; any entries
+     * still here are parked opens that outlived their grace window without a
+     * sweep, or were never reaped.  Free the bookkeeping; the open_file objects
+     * themselves belong to thread free-lists that are torn down separately. */
+    HASH_ITER(hh, table->by_pid, entry, tmp)
+    {
+        HASH_DELETE(hh, table->by_pid, entry);
+        free(entry);
+    }
+
+    pthread_mutex_destroy(&table->lock);
+} /* chimera_smb_durable_table_destroy */
+
+SYMBOL_EXPORT void
+chimera_smb_durable_register(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_open_file     *open_file,
+    uint64_t                          session_id,
+    const char                       *name,
+    uint32_t                          name_len)
+{
+    struct chimera_smb_durable_entry *entry = calloc(1, sizeof(*entry));
+
+    entry->persistent_id = open_file->file_id.pid;
+    entry->session_id    = session_id;
+    entry->open_file     = open_file;
+    entry->parked        = false;
+    memcpy(entry->create_guid, open_file->create_guid, sizeof(entry->create_guid));
+
+    if (name_len > sizeof(entry->name)) {
+        name_len = sizeof(entry->name);
+    }
+    entry->name_len = name_len;
+    memcpy(entry->name, name, name_len);
+
+    pthread_mutex_lock(&shared->durable.lock);
+    HASH_ADD(hh, shared->durable.by_pid, persistent_id, sizeof(entry->persistent_id), entry);
+    pthread_mutex_unlock(&shared->durable.lock);
+} /* chimera_smb_durable_register */
+
+SYMBOL_EXPORT void
+chimera_smb_durable_forget(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id)
+{
+    struct chimera_smb_durable_entry *entry;
+
+    pthread_mutex_lock(&shared->durable.lock);
+    HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
+    if (entry) {
+        HASH_DELETE(hh, shared->durable.by_pid, entry);
+    }
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    if (entry) {
+        free(entry);
+    }
+} /* chimera_smb_durable_forget */
+
+SYMBOL_EXPORT void
+chimera_smb_durable_park(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_open_file     *open_file)
+{
+    struct chimera_smb_durable_entry *entry;
+    uint64_t                          pid = open_file->file_id.pid;
+    struct timespec                   now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    pthread_mutex_lock(&shared->durable.lock);
+    HASH_FIND(hh, shared->durable.by_pid, &pid, sizeof(pid), entry);
+    if (entry) {
+        entry->parked            = true;
+        entry->deadline          = now;
+        entry->deadline.tv_sec  += open_file->durable_timeout_ms / 1000;
+        entry->deadline.tv_nsec += (open_file->durable_timeout_ms % 1000) * 1000000L;
+        if (entry->deadline.tv_nsec >= 1000000000L) {
+            entry->deadline.tv_sec  += 1;
+            entry->deadline.tv_nsec -= 1000000000L;
+        }
+    }
+    pthread_mutex_unlock(&shared->durable.lock);
+} /* chimera_smb_durable_park */
+
+SYMBOL_EXPORT struct chimera_smb_open_file *
+chimera_smb_durable_claim(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id,
+    const uint8_t                    *create_guid,
+    uint64_t                          session_id,
+    const char                       *name,
+    uint32_t                          name_len,
+    uint32_t                         *status)
+{
+    struct chimera_smb_durable_entry *entry;
+    struct chimera_smb_open_file     *open_file = NULL;
+
+    pthread_mutex_lock(&shared->durable.lock);
+
+    HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
+
+    if (!entry) {
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (!entry->parked) {
+        /* The handle is still live on another (multi-)channel — a second
+         * reconnect cannot steal it. */
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (create_guid && memcmp(entry->create_guid, create_guid, 16) != 0) {
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (entry->session_id != session_id) {
+        /* A different session/user may not reclaim the handle. */
+        *status = SMB2_STATUS_ACCESS_DENIED;
+    } else if (entry->name_len != name_len || memcmp(entry->name, name, name_len) != 0) {
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else {
+        /* Claim it: flip out of the parked state so the sweeper leaves it
+         * alone, and hand the surviving open back to the caller to re-home. */
+        entry->parked = false;
+        open_file     = entry->open_file;
+        *status = SMB2_STATUS_SUCCESS;
+    }
+
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    return open_file;
+} /* chimera_smb_durable_claim */
+
+void
+chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
+{
+    struct chimera_server_smb_shared *shared = thread->shared;
+    struct chimera_smb_durable_entry *entry, *tmp;
+    struct chimera_smb_durable_entry *expired = NULL;  /* singly-linked via hh.next reuse */
+    struct timespec                   now;
+
+    /* Collect expired parked entries under the registry lock (removing them
+     * from the hash so a peer thread's sweep cannot also claim them), then do
+     * the heavyweight teardown after the lock is dropped. */
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    pthread_mutex_lock(&shared->durable.lock);
+
+    HASH_ITER(hh, shared->durable.by_pid, entry, tmp)
+    {
+        if (!entry->parked) {
+            continue;
+        }
+        if (chimera_timespec_cmp(&now, &entry->deadline) < 0) {
+            continue;
+        }
+        HASH_DELETE(hh, shared->durable.by_pid, entry);
+        entry->reap_next = expired;
+        expired          = entry;
+    }
+
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    while (expired) {
+        struct chimera_smb_open_file *open_file = expired->open_file;
+        entry   = expired;
+        expired = expired->hh.next;
+
+        chimera_smb_debug("durable: reaping expired handle pid=%lx '%.*s'",
+                          open_file->file_id.pid, open_file->name_len, open_file->name);
+
+        chimera_smb_open_file_drain_locks(thread, open_file);
+        if (open_file->handle) {
+            chimera_vfs_release(thread->vfs_thread, open_file->handle);
+            open_file->handle = NULL;
+        }
+        chimera_smb_open_file_free(thread, open_file);
+
+        free(entry);
+    }
+} /* chimera_smb_durable_sweep */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdatomic.h>
 #include <time.h>
 #include <utlist.h>
 #include <netinet/in.h>
@@ -113,6 +114,7 @@ struct chimera_smb_config {
     int                            num_dialects;
     int                            num_nic_info;
     int                            soft_fail_bad_req;
+    int                            persistent_handles;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -129,6 +131,12 @@ struct chimera_smb_share {
     struct chimera_smb_share          *prev;
     struct chimera_smb_share          *next;
     struct chimera_smb_sharemode_table sharemode;
+    /* Continuous-availability share: advertised to clients (SMB2_SHARE_CAP_
+     * CONTINUOUS_AVAILABILITY) and required before a persistent (as opposed to
+     * merely durable) handle may be granted.  For this initial pass it is set
+     * from the global smb_persistent_handles flag; a per-share config knob
+     * will replace that later. */
+    bool                               continuous_availability;
 };
 
 struct chimera_smb_conn;
@@ -576,25 +584,61 @@ struct chimera_smb_conn {
     char                               remote_addr[128];
 };
 
+/* Default and ceiling for a durable handle's reconnect grace window.  A v2
+ * client may request a timeout; we honor it up to the ceiling, falling back to
+ * the default when the client requests 0.  v1 handles have no timeout field on
+ * the wire and always use the default. */
+#define CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS 60000
+#define CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS     300000
+
+/* One parked-or-live durable open, indexed by its (now globally unique)
+ * persistent id.  For an initial in-memory pass this object IS the durable
+ * state; the future persistence layer will serialize these fields. */
+struct chimera_smb_durable_entry {
+    uint64_t                          persistent_id; /* hash key == open_file->file_id.pid */
+    uint8_t                           create_guid[16];
+    uint64_t                          session_id; /* original owning session */
+    struct timespec                   deadline;  /* reconnect grace; valid only while parked */
+    bool                              parked;    /* true => disconnected, awaiting reconnect */
+    struct chimera_smb_open_file     *open_file;
+    uint32_t                          name_len;
+    char                              name[SMB_FILENAME_MAX];
+    /* Transient worklist link used by the sweeper after the entry has been
+     * removed from the hash; not valid while the entry is in the table. */
+    struct chimera_smb_durable_entry *reap_next;
+    struct UT_hash_handle             hh;
+};
+
+struct chimera_smb_durable_table {
+    pthread_mutex_t                   lock;
+    struct chimera_smb_durable_entry *by_pid;
+};
+
 struct chimera_server_smb_shared {
-    struct chimera_smb_config   config;
-    int                         rdma;
-    enum evpl_protocol_id       tcp_protocol;
-    uint8_t                     guid[SMB2_GUID_SIZE];
-    gss_name_t                  svc;
-    gss_cred_id_t               srv_cred;
-    struct chimera_vfs         *vfs;
-    struct prometheus_metrics  *metrics;
-    struct evpl_endpoint       *endpoint;
-    struct evpl_endpoint       *endpoint_rdma;
-    struct evpl_listener       *listener;
-    struct chimera_smb_session *sessions;
-    struct chimera_smb_session *free_sessions;
-    pthread_mutex_t             sessions_lock;
-    struct chimera_smb_share   *shares;
-    pthread_mutex_t             shares_lock;
-    struct chimera_smb_tree    *free_trees;
-    pthread_mutex_t             trees_lock;
+    struct chimera_smb_config        config;
+    int                              rdma;
+    enum evpl_protocol_id            tcp_protocol;
+    uint8_t                          guid[SMB2_GUID_SIZE];
+    gss_name_t                       svc;
+    gss_cred_id_t                    srv_cred;
+    struct chimera_vfs              *vfs;
+    struct prometheus_metrics       *metrics;
+    struct evpl_endpoint            *endpoint;
+    struct evpl_endpoint            *endpoint_rdma;
+    struct evpl_listener            *listener;
+    struct chimera_smb_session      *sessions;
+    struct chimera_smb_session      *free_sessions;
+    pthread_mutex_t                  sessions_lock;
+    struct chimera_smb_share        *shares;
+    pthread_mutex_t                  shares_lock;
+    struct chimera_smb_tree         *free_trees;
+    pthread_mutex_t                  trees_lock;
+    /* Monotonic, process-global allocator for file persistent ids.  Replaces
+     * the old per-tree counter so persistent ids stay unique across tree
+     * teardowns — a precondition for durable-handle reconnect lookup. */
+    _Atomic uint64_t                 next_persistent_id;
+    /* In-memory durable/persistent handle registry (see struct above). */
+    struct chimera_smb_durable_table durable;
 };
 
 /* Forward decl so the inline open_file release paths can call into
@@ -603,6 +647,41 @@ void
 chimera_smb_open_file_drain_locks(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_open_file     *open_file);
+
+/* Durable/persistent handle registry (smb_durable.c). */
+void
+chimera_smb_durable_table_init(
+    struct chimera_smb_durable_table *table);
+void
+chimera_smb_durable_table_destroy(
+    struct chimera_smb_durable_table *table);
+void
+chimera_smb_durable_register(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_open_file     *open_file,
+    uint64_t                          session_id,
+    const char                       *name,
+    uint32_t                          name_len);
+void
+chimera_smb_durable_forget(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id);
+void
+chimera_smb_durable_park(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_open_file     *open_file);
+struct chimera_smb_open_file *
+chimera_smb_durable_claim(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id,
+    const uint8_t                    *create_guid,
+    uint64_t                          session_id,
+    const char                       *name,
+    uint32_t                          name_len,
+    uint32_t                         *status);
+void
+chimera_smb_durable_sweep(
+    struct chimera_server_smb_thread *thread);
 
 struct chimera_server_smb_thread {
     struct evpl                       *evpl;
@@ -622,6 +701,11 @@ struct chimera_server_smb_thread {
     struct evpl_doorbell               notify_doorbell;
     struct chimera_smb_notify_request *notify_ready;
     pthread_mutex_t                    notify_ready_lock;
+
+    /* Periodic sweep of the shared durable-handle registry for parked opens
+     * whose reconnect grace window has expired.  Each thread sweeps the shared
+     * table; entries are claimed under the registry lock so peers never race. */
+    struct evpl_timer                  durable_sweeper;
 };
 
 
@@ -996,8 +1080,25 @@ chimera_smb_tree_free(
         HASH_ITER(hh, tree->open_files[i], open_file, tmp)
         {
             chimera_smb_abort_if(open_file->refcnt == 0, "open file refcnt is 0 at tree destruction");
-            open_file->flags |= CHIMERA_SMB_OPEN_FILE_CLOSED;
             HASH_DELETE(hh, tree->open_files[i], open_file);
+
+            /* Durable/persistent opens survive the connection: keep the object
+             * allocated with its leases, share reservation, byte-range locks
+             * and VFS handle intact, and hand ownership to the durable registry
+             * with a reconnect deadline.  Do NOT mark CLOSED (a reconnect must
+             * be able to re-home it), drain locks, release sharemode, or free.
+             * The single tree reference becomes the registry's reference, so
+             * refcnt is left untouched (steady-state 1). */
+            if (open_file->durable_flags) {
+                open_file->flags      |= CHIMERA_SMB_OPEN_FILE_PARKED;
+                open_file->create_conn = NULL;
+                /* park acquires the registry lock under this bucket lock —
+                 * the bucket -> registry order is observed everywhere. */
+                chimera_smb_durable_park(shared, open_file);
+                continue;
+            }
+
+            open_file->flags |= CHIMERA_SMB_OPEN_FILE_CLOSED;
 
             if (open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&
                 tree->share) {
@@ -1118,6 +1219,12 @@ chimera_smb_open_file_release(
     open_file->refcnt--;
 
     if (open_file->refcnt == 0) {
+        /* Final teardown of a live durable open (e.g. an explicit CLOSE):
+         * drop its registry entry before the object is recycled. */
+        if (open_file->durable_flags) {
+            chimera_smb_durable_forget(request->compound->thread->shared,
+                                       open_file->file_id.pid);
+        }
         chimera_smb_open_file_drain_locks(request->compound->thread, open_file);
         if (open_file->handle) {
             chimera_vfs_release(request->compound->thread->vfs_thread, open_file->handle);
@@ -1155,6 +1262,9 @@ chimera_smb_open_file_release_nr(
     open_file->refcnt--;
 
     if (open_file->refcnt == 0) {
+        if (open_file->durable_flags) {
+            chimera_smb_durable_forget(thread->shared, open_file->file_id.pid);
+        }
         chimera_smb_open_file_drain_locks(thread, open_file);
         if (open_file->handle) {
             chimera_vfs_release(thread->vfs_thread, open_file->handle);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -348,6 +348,38 @@ chimera_smb_create_gen_open_file(
                                         &request->session_handle->session->cred);
     }
 
+    /* Durable / persistent handle grant.  Initial in-memory pass with a lax
+     * policy: granted whenever the client asks and the feature is enabled,
+     * independent of the oplock/lease actually held.  Persistent (vs merely
+     * durable) additionally requires a continuous-availability share; absent
+     * that we silently downgrade to durable-v2, which is spec-legal. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share &&
+        thread->shared->config.persistent_handles) {
+        uint32_t ctx = request->create.ctx_present_mask;
+
+        if (ctx & CHIMERA_SMB_CREATE_CTX_DH2Q) {
+            open_file->durable_flags = CHIMERA_SMB_DURABLE_V2;
+            memcpy(open_file->create_guid, request->create.dh2q.create_guid, 16);
+
+            if ((request->create.dh2q.flags & SMB2_DHANDLE_FLAG_PERSISTENT) &&
+                tree->share->continuous_availability) {
+                open_file->durable_flags |= CHIMERA_SMB_DURABLE_PERSISTENT;
+            }
+
+            if (request->create.dh2q.timeout_ms == 0) {
+                open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
+            } else if (request->create.dh2q.timeout_ms > CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS) {
+                open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS;
+            } else {
+                open_file->durable_timeout_ms = request->create.dh2q.timeout_ms;
+            }
+        } else if (ctx & CHIMERA_SMB_CREATE_CTX_DHNQ) {
+            /* Durable v1: no timeout or create-guid on the wire. */
+            open_file->durable_flags      = CHIMERA_SMB_DURABLE_V1;
+            open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
+        }
+    }
+
     open_file_bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
 
     pthread_mutex_lock(&tree->open_files_lock[open_file_bucket]);
@@ -355,6 +387,15 @@ chimera_smb_create_gen_open_file(
     HASH_ADD(hh, tree->open_files[open_file_bucket], file_id, sizeof(open_file->file_id), open_file);
 
     pthread_mutex_unlock(&tree->open_files_lock[open_file_bucket]);
+
+    /* Register the durable handle in the shared registry so it survives a
+     * disconnect and can be reclaimed on reconnect.  Done outside the bucket
+     * lock to keep the bucket -> registry lock order (see smb_durable.c). */
+    if (open_file->durable_flags) {
+        chimera_smb_durable_register(thread->shared, open_file,
+                                     request->session_handle->session->session_id,
+                                     open_file->name, open_file->name_len);
+    }
 
     compound->saved_file_id = open_file->file_id;
 
@@ -375,10 +416,15 @@ chimera_smb_create_gen_open_file_normal(
 {
     struct chimera_smb_open_file *open_file;
 
+    /* Persistent ids are drawn from a process-global monotonic counter rather
+     * than a per-tree one so they stay unique across tree teardowns — durable
+     * reconnect looks an open up by persistent id alone. */
+    uint64_t                      pid = atomic_fetch_add(&request->compound->thread->shared->next_persistent_id, 1);
+
     open_file = chimera_smb_create_gen_open_file(request,
                                                  CHIMERA_SMB_OPEN_FILE_TYPE_FILE,
                                                  NULL,
-                                                 ++request->tree->next_file_id,
+                                                 pid,
                                                  parent_fh,
                                                  parent_fh_len,
                                                  name,
@@ -881,6 +927,66 @@ chimera_smb_revalidate_tree(
 
 } /* chimera_smb_revalidate_tree */
 
+/* Durable-handle reconnect (DH2C / DHnC).  Reclaims a parked open that
+ * survived its previous connection and re-homes it into the reconnecting
+ * tree, then replies as a normal OPEN of the surviving file. */
+static void
+chimera_smb_durable_reconnect(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    struct chimera_server_smb_shared *shared = thread->shared;
+    struct chimera_smb_tree          *tree   = request->tree;
+    struct chimera_smb_open_file     *open_file;
+    const uint8_t                    *create_guid = NULL;
+    uint64_t                          persistent_id;
+    uint32_t                          status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    int                               bucket;
+
+    if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2C) {
+        persistent_id = request->create.dh2c.persistent;
+        create_guid   = request->create.dh2c.create_guid;
+    } else {
+        persistent_id = request->create.dhnc.persistent;
+    }
+
+    open_file = chimera_smb_durable_claim(shared, persistent_id, create_guid,
+                                          request->session_handle->session->session_id,
+                                          request->create.name, request->create.name_len,
+                                          &status);
+
+    if (!open_file) {
+        chimera_smb_complete_request(request, status);
+        return;
+    }
+
+    /* Re-home the surviving open into the reconnecting tree.  The persistent
+     * id is unchanged; the volatile id is reissued (spec permits this).  The
+     * registry reference becomes the new tree reference; we add one more for
+     * this in-flight request, which the getattr callback releases below. */
+    open_file->flags      &= ~CHIMERA_SMB_OPEN_FILE_PARKED;
+    open_file->create_conn = request->compound->conn;
+    open_file->file_id.vid = chimera_rand64();
+    open_file->refcnt      = 2;
+
+    bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
+    pthread_mutex_lock(&tree->open_files_lock[bucket]);
+    HASH_ADD(hh, tree->open_files[bucket], file_id, sizeof(open_file->file_id), open_file);
+    pthread_mutex_unlock(&tree->open_files_lock[bucket]);
+
+    request->create.r_open_file        = open_file;
+    request->create.create_disposition = SMB2_FILE_OPEN; /* reply emits OPENED */
+    request->compound->saved_file_id   = open_file->file_id;
+
+    /* Refresh the network-open-info from the surviving handle, then reply.
+     * Reuses the normal create getattr callback (releases the request ref). */
+    chimera_vfs_getattr(thread->vfs_thread,
+                        &request->session_handle->session->cred,
+                        open_file->handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_smb_create_open_getattr_callback,
+                        request);
+} /* chimera_smb_durable_reconnect */
+
 void
 chimera_smb_create(struct chimera_smb_request *request)
 {
@@ -928,6 +1034,15 @@ chimera_smb_create(struct chimera_smb_request *request)
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 
     } else {
+
+        /* Durable-handle reconnect short-circuits the normal open path: the
+         * file is already open (parked); we just reclaim and re-home it. */
+        if (request->compound->thread->shared->config.persistent_handles &&
+            (request->create.ctx_present_mask &
+             (CHIMERA_SMB_CREATE_CTX_DH2C | CHIMERA_SMB_CREATE_CTX_DHNC))) {
+            chimera_smb_durable_reconnect(request);
+            return;
+        }
 
         clock_gettime(CLOCK_MONOTONIC, &now);
 
@@ -1095,12 +1210,62 @@ build_rqls_response(
     return needed;
 } /* build_rqls_response */
 
+/* Build the DH2Q (durable-handle-request-v2) response body — 8 bytes:
+ * Timeout(4) | Flags(4).  Emitted only when a durable-v2 grant was made;
+ * Flags echoes PERSISTENT when the grant is persistent. */
+static int
+build_dh2q_response(
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    struct chimera_smb_open_file *of = request->create.r_open_file;
+    uint32_t                      timeout, flags;
+
+    if (!of || !(of->durable_flags & CHIMERA_SMB_DURABLE_V2) || out_size < 8) {
+        return -1;
+    }
+
+    timeout = (uint32_t) of->durable_timeout_ms;
+    flags   = (of->durable_flags & CHIMERA_SMB_DURABLE_PERSISTENT) ?
+        SMB2_DHANDLE_FLAG_PERSISTENT : 0;
+
+    out[0] = timeout & 0xff;
+    out[1] = (timeout >> 8) & 0xff;
+    out[2] = (timeout >> 16) & 0xff;
+    out[3] = (timeout >> 24) & 0xff;
+    out[4] = flags & 0xff;
+    out[5] = (flags >> 8) & 0xff;
+    out[6] = (flags >> 16) & 0xff;
+    out[7] = (flags >> 24) & 0xff;
+    return 8;
+} /* build_dh2q_response */
+
+/* Build the DHnQ (durable-handle-request v1) response body — 8 reserved
+ * (zero) bytes.  Emitted only when a durable-v1 grant was made. */
+static int
+build_dhnq_response(
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    struct chimera_smb_open_file *of = request->create.r_open_file;
+
+    if (!of || !(of->durable_flags & CHIMERA_SMB_DURABLE_V1) || out_size < 8) {
+        return -1;
+    }
+
+    memset(out, 0, 8);
+    return 8;
+} /* build_dhnq_response */
+
 /* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
 static const struct chimera_smb_create_response_emitter smb_create_response_emitters[] = {
     { CHIMERA_SMB_CREATE_CTX_MXAC, "MxAc", build_mxac_response  },
     { CHIMERA_SMB_CREATE_CTX_RQLS, "RqLs", build_rqls_response  },
-    /* Phase 3: + DH2Q (durable handle grant), DHnQ
-     * Phase 8: + QFid (32-byte on-disk id) */
+    { CHIMERA_SMB_CREATE_CTX_DH2Q, "DH2Q", build_dh2q_response  },
+    { CHIMERA_SMB_CREATE_CTX_DHNQ, "DHnQ", build_dhnq_response  },
+    /* Phase 8: + QFid (32-byte on-disk id) */
     { 0,                           NULL,   NULL                },
 };
 /* *INDENT-ON* */

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -102,6 +102,9 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     if (dialect >= 0x300 && (shared->config.capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL)) {
         conn->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
     }
+    if (dialect >= 0x300 && shared->config.persistent_handles) {
+        conn->capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
+    }
 
     if (request->negotiate.security_mode & SMB2_SIGNING_REQUIRED) {
         conn->flags |= CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED;

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -124,8 +124,15 @@ chimera_smb_tree_connect_reply(
     /* Share Flags*/
     evpl_iovec_cursor_append_uint32(reply_cursor, 0);
 
-    /* Capabilitiers */
-    evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    /* Capabilities — advertise continuous availability for disk shares backed
+    * by a CA-enabled share (gates persistent-handle grants on the client). */
+    uint32_t share_caps = 0;
+
+    if (!request->tree_connect.is_ipc && request->tree &&
+        request->tree->share && request->tree->share->continuous_availability) {
+        share_caps |= SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY;
+    }
+    evpl_iovec_cursor_append_uint32(reply_cursor, share_caps);
 
     /* Maximal Access 0x001F01FF (ful RW) */
     evpl_iovec_cursor_append_uint32(reply_cursor, 0x001F01FF);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -25,6 +25,11 @@ struct chimera_smb_file_id {
 #define CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY       0x00000001
 #define CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE 0x00000002
 #define CHIMERA_SMB_OPEN_FILE_CLOSED               0x00000004
+/* Open survived its owning connection's teardown and is parked in the shared
+ * durable-handle table awaiting reconnect or expiry.  While set, the open is
+ * not present in any tree's open_files[] hash and is owned solely by the
+ * durable table (refcnt == 1). Cleared when a reconnect re-homes it. */
+#define CHIMERA_SMB_OPEN_FILE_PARKED               0x00000008
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -839,6 +839,189 @@ test_negotiate_duplicate_context_rejected(void)
     }
 } /* test_negotiate_duplicate_context_rejected */
 
+/* ------------------------------------------------------------------ *
+*  Durable / persistent handle: response emit + registry lifecycle    *
+* ------------------------------------------------------------------ */
+
+static void
+test_create_response_dh2q_persistent(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    /* A persistent-v2 grant: the emitter echoes Timeout + PERSISTENT flag. */
+    req.create.ctx_present_mask  = CHIMERA_SMB_CREATE_CTX_DH2Q;
+    open_file.durable_flags      = CHIMERA_SMB_DURABLE_V2 | CHIMERA_SMB_DURABLE_PERSISTENT;
+    open_file.durable_timeout_ms = 30000;
+    req.create.r_open_file       = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    /* 24-byte header+name+pad, then 8-byte body: Timeout(4)=30000, Flags(4)=0x02. */
+    if (ctx_len == 32 &&
+        ctx_buf[16] == 'D' && ctx_buf[17] == 'H' && ctx_buf[18] == '2' && ctx_buf[19] == 'Q' &&
+        ctx_buf[24] == 0x30 && ctx_buf[25] == 0x75 && ctx_buf[26] == 0 && ctx_buf[27] == 0 &&
+        ctx_buf[28] == SMB2_DHANDLE_FLAG_PERSISTENT &&
+        ctx_buf[29] == 0 && ctx_buf[30] == 0 && ctx_buf[31] == 0) {
+        TEST_PASS("DH2Q response: timeout + PERSISTENT flag emitted");
+    } else {
+        TEST_FAIL("DH2Q response: timeout + PERSISTENT flag emitted");
+        fprintf(stderr, "    got ctx_len=%u\n", ctx_len);
+    }
+} /* test_create_response_dh2q_persistent */
+
+static void
+test_create_response_dhnq_v1(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    req.create.ctx_present_mask = CHIMERA_SMB_CREATE_CTX_DHNQ;
+    open_file.durable_flags     = CHIMERA_SMB_DURABLE_V1;
+    req.create.r_open_file      = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    /* 8-byte reserved (zero) body. */
+    if (ctx_len == 32 &&
+        ctx_buf[16] == 'D' && ctx_buf[17] == 'H' && ctx_buf[18] == 'n' && ctx_buf[19] == 'Q' &&
+        ctx_buf[24] == 0 && ctx_buf[25] == 0 && ctx_buf[26] == 0 && ctx_buf[27] == 0 &&
+        ctx_buf[28] == 0 && ctx_buf[29] == 0 && ctx_buf[30] == 0 && ctx_buf[31] == 0) {
+        TEST_PASS("DHnQ response: 8 reserved bytes emitted");
+    } else {
+        TEST_FAIL("DHnQ response: 8 reserved bytes emitted");
+    }
+} /* test_create_response_dhnq_v1 */
+
+static void
+test_create_response_dh2q_suppressed_without_grant(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    /* Client asked (DH2Q) but no durable grant was made (feature off / not a
+     * share): the emitter must suppress the response context. */
+    req.create.ctx_present_mask = CHIMERA_SMB_CREATE_CTX_DH2Q;
+    open_file.durable_flags     = 0;
+    req.create.r_open_file      = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    if (ctx_len == 0) {
+        TEST_PASS("DH2Q response suppressed when no grant made");
+    } else {
+        TEST_FAIL("DH2Q response suppressed when no grant made");
+    }
+} /* test_create_response_dh2q_suppressed_without_grant */
+
+static void
+test_durable_register_park_claim(void)
+{
+    struct chimera_server_smb_shared *shared = calloc(1, sizeof(*shared));
+    struct chimera_smb_open_file      of;
+    struct chimera_smb_open_file     *claimed;
+    uint8_t                           guid[16];
+    uint32_t                          status;
+    int                               i;
+
+    chimera_smb_durable_table_init(&shared->durable);
+
+    memset(&of, 0, sizeof(of));
+    for (i = 0; i < 16; i++) {
+        guid[i] = (uint8_t) (0x10 + i);
+    }
+    of.file_id.pid        = 0xABCDEF;
+    of.durable_flags      = CHIMERA_SMB_DURABLE_V2;
+    of.durable_timeout_ms = 60000;
+    memcpy(of.create_guid, guid, 16);
+
+    chimera_smb_durable_register(shared, &of, 42, "foo.txt", 7);
+
+    /* Before park: live, not reclaimable. */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 42, "foo.txt", 7, &status);
+    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
+        TEST_FAIL("durable: live (unparked) handle is not reclaimable");
+    } else {
+        TEST_PASS("durable: live (unparked) handle is not reclaimable");
+    }
+
+    chimera_smb_durable_park(shared, &of);
+
+    /* Wrong create-guid is rejected. */
+    guid[0] = 0xFF;
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 42, "foo.txt", 7, &status);
+    guid[0] = 0x10;
+    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
+        TEST_FAIL("durable: create-guid mismatch rejected");
+    } else {
+        TEST_PASS("durable: create-guid mismatch rejected");
+    }
+
+    /* Wrong session is ACCESS_DENIED. */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 99, "foo.txt", 7, &status);
+    if (claimed != NULL || status != SMB2_STATUS_ACCESS_DENIED) {
+        TEST_FAIL("durable: session mismatch -> ACCESS_DENIED");
+    } else {
+        TEST_PASS("durable: session mismatch -> ACCESS_DENIED");
+    }
+
+    /* Matching reconnect succeeds and returns the surviving open. */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 42, "foo.txt", 7, &status);
+    if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
+        TEST_PASS("durable: matching reconnect reclaims the open");
+    } else {
+        TEST_FAIL("durable: matching reconnect reclaims the open");
+    }
+
+    /* A second reconnect must fail — the handle is now live again. */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 42, "foo.txt", 7, &status);
+    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
+        TEST_FAIL("durable: double-reconnect rejected");
+    } else {
+        TEST_PASS("durable: double-reconnect rejected");
+    }
+
+    /* After forget, the persistent id is unknown. */
+    chimera_smb_durable_forget(shared, 0xABCDEF);
+    chimera_smb_durable_park(shared, &of);  /* no entry -> no-op */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, 42, "foo.txt", 7, &status);
+    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
+        TEST_FAIL("durable: forgotten handle not found");
+    } else {
+        TEST_PASS("durable: forgotten handle not found");
+    }
+
+    /* v1 reconnect (DHnC): no create-guid supplied. */
+    of.file_id.pid   = 0x999;
+    of.durable_flags = CHIMERA_SMB_DURABLE_V1;
+    chimera_smb_durable_register(shared, &of, 7, "bar", 3);
+    chimera_smb_durable_park(shared, &of);
+    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, 7, "bar", 3, &status);
+    if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
+        TEST_PASS("durable: v1 (no-guid) reconnect reclaims the open");
+    } else {
+        TEST_FAIL("durable: v1 (no-guid) reconnect reclaims the open");
+    }
+
+    chimera_smb_durable_table_destroy(&shared->durable);
+    free(shared);
+} /* test_durable_register_park_claim */
+
 int
 main(
     int   argc,
@@ -878,6 +1061,12 @@ main(
     test_create_response_mxac_on_maximum_allowed();
     test_create_response_mxac_suppressed_on_specific_access();
     test_create_response_empty_when_no_mxac_bit();
+
+    fprintf(stderr, "=== Durable/persistent handles ===\n");
+    test_create_response_dh2q_persistent();
+    test_create_response_dhnq_v1();
+    test_create_response_dh2q_suppressed_without_grant();
+    test_durable_register_park_claim();
 
     fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
     return failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Initial, **in-memory** pass at SMB3 durable/persistent file handles, gated behind a new JSON flag **`smb_persistent_handles`** (default **off**); with it off, behaviour is unchanged. Backend persistence for true cross-restart durability is a deliberate follow-up — the serialization seams are marked in the code.

Decisions: support **both** durable v1 (DHnQ/DHnC) and v2/persistent (DH2Q/DH2C); **lax** grant policy (granted on request regardless of oplock/lease).

## What's included

- **Config**: `smb_persistent_handles` plumbed `server_config` -> `smb_config` -> `shared->config`.
- **Capabilities** (gated): `SMB2_GLOBAL_CAP_PERSISTENT_HANDLES` (NEGOTIATE, dialect >= 3.0) and `SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY` (TREE_CONNECT; new per-share `continuous_availability` flag).
- **Global persistent-id allocator**: atomic, replacing the per-tree counter so ids stay unique across tree teardowns (reconnect lookup precondition).
- **Grant on CREATE**: durable v1/v2/persistent set on the open; `DH2Q`/`DHnQ` response-context emitters.
- **In-memory registry** (`smb_durable.c`): durable opens survive connection drop by being *parked* (the `open_file` is kept alive, so its vfs_state leases, share reservation, byte-range locks and VFS handle stay valid), reclaimed on reconnect (DH2C/DHnC), and reaped by a per-thread `evpl_timer` sweeper when the grace window expires.
- **Lock order** bucket -> registry -> vfs_state observed everywhere; refcount invariant: parked = 1 (registry owns) -> reconnect bumps to 2 -> reaper frees.

## Reviewer focus

- Lease/share survival is *implicit* (relies on not freeing parked opens); CLOSE/`open_file_release` calls `chimera_smb_durable_forget` so explicitly-closed durable handles drop their registry entry.
- Multi-channel mid-session connection loss does **not** park (only session teardown does) — out of scope for this pass.

## Testing

- 11 new unit tests in `phase0_contexts_test.c` (DH2Q/DHnQ emission incl. suppression; registry register->park->claim lifecycle, double-reconnect rejection, forget, v1 no-guid reconnect).
- `make syntax-check`, `make reuse-lint`, Debug + Release builds clean, full non-KVM `ctest` (1604/1604). KVM image build (docker) can't run in the dev sandbox; CI exercises it.