### PR TITLE
vfs: acquire implicit leases for leaseless I/O

### DIFF
--- a/src/server/nfs/nfs4_proc_link.c
+++ b/src/server/nfs/nfs4_proc_link.c
@@ -106,20 +106,9 @@ chimera_nfs4_link(
         return;
     }
 
-    /* RFC 7530 §10.4.5: adding a hard link to a delegated file (the SAVEFH
-     * source) must recall the delegation first. */
-    if (chimera_server_config_get_nfs4_delegations(thread->shared->config)) {
-        uint64_t fh_hash = XXH3_64bits(req->saved_fh, req->saved_fhlen) & INT64_MAX;
-
-        if (chimera_vfs_state_break_caching(thread->vfs->vfs_state,
-                                            req->saved_fh, req->saved_fhlen,
-                                            fh_hash)) {
-            res->status = NFS4ERR_DELAY;
-            chimera_nfs4_compound_complete(req, NFS4ERR_DELAY);
-            return;
-        }
-    }
-
+    /* RFC 7530 §10.4.5 (hard link to a delegated file must recall the
+     * delegation) is now enforced centrally by chimera_vfs_link_at(), which
+     * recalls any caching lease on the SAVEFH source before linking. */
     chimera_vfs_open_fh(thread->vfs_thread,
                         &req->cred,
                         req->fh,

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -260,13 +260,23 @@ chimera_nfs4_read(
     iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
     chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
 
-    chimera_vfs_read(thread->vfs_thread, &req->cred,
-                     state_handle,
-                     args->offset,
-                     args->count,
-                     iov,
-                     256,
-                     0,
-                     chimera_nfs4_read_complete,
-                     req);
+    /* Attribute the read to the client's owner so it is mediated against
+     * other holders without recalling this client's own delegation. */
+    struct chimera_vfs_lease_owner io_owner = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
+        .client_key = open_state->owner->client->client_id,
+        .owner_lo   = state_handle->fh_hash,
+        .owner_hi   = 0,
+    };
+
+    chimera_vfs_read_owned(thread->vfs_thread, &req->cred,
+                           state_handle,
+                           args->offset,
+                           args->count,
+                           iov,
+                           256,
+                           0,
+                           &io_owner,
+                           chimera_nfs4_read_complete,
+                           req);
 } /* chimera_nfs4_read */

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -247,15 +247,26 @@ chimera_nfs4_write(
     req->nfs_state_type = state_type;
     req->args_write4    = args;
 
-    chimera_vfs_write(thread->vfs_thread, &req->cred,
-                      state_handle,
-                      args->offset,
-                      args->data.length,
-                      (args->stable != UNSTABLE4),
-                      0,
-                      0,
-                      args->data.iov,
-                      args->data.niov,
-                      chimera_nfs4_write_complete,
-                      req);
+    /* Attribute the write to the client's owner so other holders' read
+     * caches are invalidated while this client's own delegation is not
+     * recalled by its own write. */
+    struct chimera_vfs_lease_owner io_owner = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
+        .client_key = open_state->owner->client->client_id,
+        .owner_lo   = state_handle->fh_hash,
+        .owner_hi   = 0,
+    };
+
+    chimera_vfs_write_owned(thread->vfs_thread, &req->cred,
+                            state_handle,
+                            args->offset,
+                            args->data.length,
+                            (args->stable != UNSTABLE4),
+                            0,
+                            0,
+                            args->data.iov,
+                            args->data.niov,
+                            &io_owner,
+                            chimera_nfs4_write_complete,
+                            req);
 } /* chimera_nfs4_write */

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -127,30 +127,30 @@ chimera_smb_read(struct chimera_smb_request *request)
         return;
     }
 
+    struct chimera_vfs_lease_owner io_owner = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+        .client_key = request->session_handle->session->session_id,
+        .owner_lo   = request->read.open_file->file_id.pid,
+        .owner_hi   = request->read.open_file->file_id.vid,
+    };
+
     /* Mandatory byte-range lock enforcement: an exclusive lock held by a
      * different open denies reads of the locked range. */
-    {
-        struct chimera_vfs_lease_owner io_owner = {
-            .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-            .client_key = request->session_handle->session->session_id,
-            .owner_lo   = request->read.open_file->file_id.pid,
-            .owner_hi   = request->read.open_file->file_id.vid,
-        };
-
-        if (chimera_vfs_state_range_io_conflict(
-                thread->vfs_thread->vfs->vfs_state,
-                request->read.open_file->handle->fh,
-                request->read.open_file->handle->fh_len,
-                request->read.open_file->handle->fh_hash,
-                request->read.offset, request->read.length,
-                false, &io_owner)) {
-            chimera_smb_open_file_release(request, request->read.open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
-            return;
-        }
+    if (chimera_vfs_state_range_io_conflict(
+            thread->vfs_thread->vfs->vfs_state,
+            request->read.open_file->handle->fh,
+            request->read.open_file->handle->fh_len,
+            request->read.open_file->handle->fh_hash,
+            request->read.offset, request->read.length,
+            false, &io_owner)) {
+        chimera_smb_open_file_release(request, request->read.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
     }
 
-    chimera_vfs_read(
+    /* Attribute the read to this open's owner so it is mediated against
+     * other holders without recalling the client's own oplock/lease. */
+    chimera_vfs_read_owned(
         thread->vfs_thread,
         &request->session_handle->session->cred,
         request->read.open_file->handle,
@@ -159,6 +159,7 @@ chimera_smb_read(struct chimera_smb_request *request)
         request->read.iov,
         request->read.niov,
         0,
+        &io_owner,
         chimera_smb_read_callback,
         request);
 } /* chimera_smb_read */

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -75,7 +75,14 @@ chimera_smb_rdma_read_callback(
             return;
         }
 
-        chimera_vfs_write(
+        struct chimera_vfs_lease_owner io_owner = {
+            .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+            .client_key = request->session_handle->session->session_id,
+            .owner_lo   = request->write.open_file->file_id.pid,
+            .owner_hi   = request->write.open_file->file_id.vid,
+        };
+
+        chimera_vfs_write_owned(
             thread->vfs_thread,
             &request->session_handle->session->cred,
             request->write.open_file->handle,
@@ -86,6 +93,7 @@ chimera_smb_rdma_read_callback(
             0,
             request->write.iov,
             request->write.niov,
+            &io_owner,
             chimera_smb_write_callback,
             request);
     }
@@ -109,39 +117,30 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    struct chimera_vfs_lease_owner io_owner = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+        .client_key = request->session_handle->session->session_id,
+        .owner_lo   = request->write.open_file->file_id.pid,
+        .owner_hi   = request->write.open_file->file_id.vid,
+    };
+
     /* Mandatory byte-range lock enforcement: a shared lock denies writes from
-     * everyone, an exclusive lock denies writes from other opens. */
-    {
-        struct chimera_vfs_lease_owner io_owner = {
-            .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-            .client_key = request->session_handle->session->session_id,
-            .owner_lo   = request->write.open_file->file_id.pid,
-            .owner_hi   = request->write.open_file->file_id.vid,
-        };
-
-        if (chimera_vfs_state_range_io_conflict(
-                thread->vfs_thread->vfs->vfs_state,
-                request->write.open_file->handle->fh,
-                request->write.open_file->handle->fh_len,
-                request->write.open_file->handle->fh_hash,
-                request->write.offset, request->write.length,
-                true, &io_owner)) {
-            /* Release the write payload iovecs here: the normal path frees
-            * them in chimera_smb_write_callback, which we are skipping. */
-            evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
-            chimera_smb_open_file_release(request, request->write.open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
-            return;
-        }
-
-        /* A write stales every read cache on this file: break those
-         * caching oplocks/leases (to NONE), except the writer's own
-         * write cache. */
-        chimera_vfs_state_break_on_write(thread->vfs_thread->vfs->vfs_state,
-                                         request->write.open_file->handle->fh,
-                                         request->write.open_file->handle->fh_len,
-                                         request->write.open_file->handle->fh_hash,
-                                         &io_owner);
+     * everyone, an exclusive lock denies writes from other opens.  (The
+     * read-cache invalidation that used to follow here is now driven by the
+     * VFS write path via chimera_vfs_write_owned().) */
+    if (chimera_vfs_state_range_io_conflict(
+            thread->vfs_thread->vfs->vfs_state,
+            request->write.open_file->handle->fh,
+            request->write.open_file->handle->fh_len,
+            request->write.open_file->handle->fh_hash,
+            request->write.offset, request->write.length,
+            true, &io_owner)) {
+        /* Release the write payload iovecs here: the normal path frees
+        * them in chimera_smb_write_callback, which we are skipping. */
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
     }
 
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {
@@ -168,7 +167,7 @@ chimera_smb_write(struct chimera_smb_request *request)
             chunk_iov++;
         }
     } else {
-        chimera_vfs_write(
+        chimera_vfs_write_owned(
             thread->vfs_thread,
             &request->session_handle->session->cred,
             request->write.open_file->handle,
@@ -179,6 +178,7 @@ chimera_smb_write(struct chimera_smb_request *request)
             0,
             request->write.iov,
             request->write.niov,
+            &io_owner,
             chimera_smb_write_callback,
             request);
     }

--- a/src/vfs/tests/vfs_state_test.c
+++ b/src/vfs/tests/vfs_state_test.c
@@ -867,17 +867,109 @@ test_lease_test(void)
     chimera_vfs_state_destroy(state);
 } /* test_lease_test */
 
-/* Test 17: I/O hook is a no-op pass-through for Stage A ------------ */
+/* Test 17: a breakable SHARE holder (chimera's implicit I/O lease) is
+ * recalled rather than hard-denied when a conflicting client open or
+ * delegation arrives. ------------------------------------------------- */
 static void
-test_io_hook_passthrough(void)
+test_breakable_share_recall(void)
 {
-    int rc;
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       impl, deny, deleg;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
 
-    fprintf(stderr, "\ntest_io_hook_passthrough\n");
+    fprintf(stderr, "\ntest_breakable_share_recall\n");
 
-    rc = chimera_vfs_state_check_io(NULL);
-    CHECK(rc == 0, "Stage A I/O hook returns 0 (permit)");
-} /* test_io_hook_passthrough */
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Chimera's implicit lease: deny-nothing SHARE granting W, breakable. */
+    memset(&impl, 0, sizeof(impl));
+    impl.kind         = CHIMERA_VFS_LEASE_SHARE;
+    impl.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    impl.mode.denied  = 0;
+    init_owner(&impl.owner, CHIMERA_VFS_LEASE_PROTO_INTERNAL, 0, 1);
+    impl.owner.break_cb   = recording_break_cb;
+    impl.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &impl, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "implicit deny=0 share granted");
+
+    /* A real client open that denies write conflicts with the implicit W
+     * share — but because the holder is breakable, it is recalled, not
+     * denied. */
+    memset(&deny, 0, sizeof(deny));
+    deny.kind         = CHIMERA_VFS_LEASE_SHARE;
+    deny.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    deny.mode.denied  = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&deny.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &deny, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING,
+          "client deny-W open recalls implicit share (not denied)");
+    CHECK(rec.fired == 1, "implicit share break_cb fired once");
+
+    /* An NFSv4 write-delegation grant likewise recalls the implicit share
+     * (CACHING-vs-SHARE path). */
+    rec.fired        = 0;
+    impl.break_state = CHIMERA_VFS_BREAK_IDLE; /* make it recallable again */
+
+    memset(&deleg, 0, sizeof(deleg));
+    deleg.kind         = CHIMERA_VFS_LEASE_CACHING;
+    deleg.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&deleg.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xC, 0);
+
+    r = chimera_vfs_state_try_insert(state, file, &deleg, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING,
+          "NFSv4 deleg grant recalls implicit share (not denied)");
+    CHECK(rec.fired == 1, "implicit share break_cb fired for deleg conflict");
+
+    chimera_vfs_state_remove(state, file, &impl);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_breakable_share_recall */
+
+/* Test 18: a non-breakable SHARE holder (an ordinary client open) still
+ * hard-denies a conflicting acquire. --------------------------------- */
+static void
+test_nonbreakable_share_denies(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_nonbreakable_share_denies\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Ordinary client open, deny-W, NOT breakable. */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_SHARE;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    a.mode.denied  = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "non-breakable share granted");
+
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_SHARE;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED,
+          "non-breakable deny-W share still denies");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_nonbreakable_share_denies */
 
 /* Main ---------------------------------------------------------------- */
 int
@@ -906,7 +998,8 @@ main(
     test_async_acquire_cancel();
     test_release_pumps_pending();
     test_lease_test();
-    test_io_hook_passthrough();
+    test_breakable_share_recall();
+    test_nonbreakable_share_denies();
 
     fprintf(stderr, "\n========================================\n");
     fprintf(stderr, "Results: %d passed, %d failed\n", passed, failed);

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -223,6 +223,13 @@ chimera_vfs_close_thread_wake_timer(
 
     pthread_mutex_unlock(&close_thread->lock);
 
+    /* Drop implicit I/O leases that have gone idle, bounding resident
+     * per-file state for write-once / read-once workloads. */
+    if (close_thread->vfs->vfs_state) {
+        chimera_vfs_state_reap_idle(close_thread->vfs->vfs_state,
+                                    close_thread->vfs->vfs_state->implicit_idle_ms);
+    }
+
 } /* chimera_vfs_close_thread_wake */
 
 static void *

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -623,13 +623,15 @@ chimera_vfs_process_completion(
     struct evpl_doorbell *doorbell)
 {
     struct chimera_vfs_thread  *thread = container_of(doorbell, struct chimera_vfs_thread, doorbell);
-    struct chimera_vfs_request *complete_requests, *unblocked_requests, *request;
+    struct chimera_vfs_request *complete_requests, *unblocked_requests, *io_resume_requests, *request;
 
     pthread_mutex_lock(&thread->lock);
     complete_requests                 = thread->pending_complete_requests;
     unblocked_requests                = thread->unblocked_requests;
+    io_resume_requests                = thread->pending_io_resume;
     thread->pending_complete_requests = NULL;
     thread->unblocked_requests        = NULL;
+    thread->pending_io_resume         = NULL;
     pthread_mutex_unlock(&thread->lock);
 
     while (complete_requests) {
@@ -642,6 +644,13 @@ chimera_vfs_process_completion(
         request = unblocked_requests;
         LL_DELETE(unblocked_requests, request);
         request->unblock_callback(request, request->pending_handle);
+    }
+
+    /* Resume parked I/O/metadata requests on this (their owning) thread. */
+    while (io_resume_requests) {
+        request = io_resume_requests;
+        DL_DELETE(io_resume_requests, request);
+        chimera_vfs_state_io_resume(request);
     }
 
 } /* chimera_vfs_process_completion */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1231,6 +1231,10 @@ struct chimera_vfs_thread {
 
     struct chimera_vfs_request       *pending_complete_requests;
     struct chimera_vfs_request       *unblocked_requests;
+    /* Parked I/O requests being resumed on their owning thread (the lease
+     * pump runs on whatever thread released/broke a lease, but a request's
+     * dispatch+reply must run on the thread that owns its connection iovecs). */
+    struct chimera_vfs_request       *pending_io_resume;
     struct evpl_doorbell              doorbell;
     pthread_mutex_t                   lock;
     uint64_t                          anon_fh_key;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -345,6 +345,10 @@ struct chimera_vfs_request {
      * (NULL on the fast path where nothing was pinned). */
     struct chimera_vfs_lease_owner     io_owner;
     uint8_t                            io_owner_valid;
+    /* Set by chimera_vfs_io_recall(): this request is a namespace/metadata
+     * mutation that must recall every caching lease on a target file (regardless
+     * of owner) rather than hold an implicit lease. */
+    uint8_t                            io_recall_all;
     void                               ( *io_next )(
         struct chimera_vfs_request *request);
     struct chimera_vfs_file_state     *io_lease_file;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -11,6 +11,7 @@
 #include "vfs_error.h"
 #include "vfs_cred.h"
 #include "vfs_pnfs.h"
+#include "vfs_lease_types.h"
 #include "evpl/evpl.h"
 
 #define CHIMERA_VFS_PATH_MAX 4096
@@ -303,41 +304,55 @@ struct chimera_vfs_request_handle {
 #define CHIMERA_VFS_REQUEST_MAX_HANDLES 3
 
 struct chimera_vfs_request {
-    struct chimera_vfs_thread        *thread;
-    const struct chimera_vfs_cred    *cred;
-    uint32_t                          opcode;
-    enum chimera_vfs_error            status;
-    chimera_vfs_complete_callback_t   complete;
-    chimera_vfs_complete_callback_t   complete_delegate;
-    struct timespec                   start_time;
-    uint64_t                          elapsed_ns;
+    struct chimera_vfs_thread         *thread;
+    const struct chimera_vfs_cred     *cred;
+    uint32_t                           opcode;
+    enum chimera_vfs_error             status;
+    chimera_vfs_complete_callback_t    complete;
+    chimera_vfs_complete_callback_t    complete_delegate;
+    struct timespec                    start_time;
+    uint64_t                           elapsed_ns;
 
     /* Points to one page of memory that the plugin may use as desired */
-    void                             *plugin_data;
+    void                              *plugin_data;
 
     /* For use by the plugin if desired, see io_uring for example */
-    struct chimera_vfs_request_handle handle[CHIMERA_VFS_REQUEST_MAX_HANDLES];
-    uint8_t                           token_count;
+    struct chimera_vfs_request_handle  handle[CHIMERA_VFS_REQUEST_MAX_HANDLES];
+    uint8_t                            token_count;
 
-    struct chimera_vfs_module        *module;
-    void                             *proto_callback;
-    void                             *proto_private_data;
+    struct chimera_vfs_module         *module;
+    void                              *proto_callback;
+    void                              *proto_private_data;
 
     /* VFS plugins may use these while processing the request */
-    struct chimera_vfs_request       *prev;
-    struct chimera_vfs_request       *next;
+    struct chimera_vfs_request        *prev;
+    struct chimera_vfs_request        *next;
 
     /* For use by vfs core only */
-    struct chimera_vfs_request       *active_prev;
-    struct chimera_vfs_request       *active_next;
+    struct chimera_vfs_request        *active_prev;
+    struct chimera_vfs_request        *active_next;
 
-    uint8_t                           fh[CHIMERA_VFS_FH_SIZE];
-    uint32_t                          fh_len;
-    uint64_t                          fh_hash;
+    uint8_t                            fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                           fh_len;
+    uint64_t                           fh_hash;
 
-    struct chimera_vfs_open_handle   *pending_handle;
+    /* Implicit I/O lease mediation (chimera_vfs_io_lease_acquire).  For a
+     * lease-holding client (NFSv4 delegation, SMB oplock) the protocol fills
+     * io_owner + io_owner_valid so the I/O coalesces with the client's own
+     * lease instead of recalling it.  io_next is the continuation invoked
+     * once the lease is held (normally chimera_vfs_dispatch); io_lease_file
+     * is the per-file state whose implicit lease this request has pinned
+     * (NULL on the fast path where nothing was pinned). */
+    struct chimera_vfs_lease_owner     io_owner;
+    uint8_t                            io_owner_valid;
+    void                               ( *io_next )(
+        struct chimera_vfs_request *request);
+    struct chimera_vfs_file_state     *io_lease_file;
+    struct chimera_vfs_pending_acquire io_lease_ticket;
 
-    void                              ( *unblock_callback )(
+    struct chimera_vfs_open_handle    *pending_handle;
+
+    void                               ( *unblock_callback )(
         struct chimera_vfs_request     *request,
         struct chimera_vfs_open_handle *handle);
 

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -356,6 +356,24 @@ chimera_vfs_complete_delegate(struct chimera_vfs_request *request)
     evpl_ring_doorbell(&thread->doorbell);
 } /* chimera_vfs_complete_delegate */
 
+/* Marshal a parked I/O request back to its owning thread to resume.  The
+ * lease pump that unblocks it may run on any thread (the one that released a
+ * lease, acked/revoked a break, or ran the idle reaper), but the request's
+ * dispatch and reply must run on request->thread, whose connection iovecs are
+ * thread-local.  The owning thread drains pending_io_resume in
+ * chimera_vfs_process_completion(). */
+static inline void
+chimera_vfs_io_resume_post(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread *thread = request->thread;
+
+    pthread_mutex_lock(&thread->lock);
+    DL_APPEND(thread->pending_io_resume, request);
+    pthread_mutex_unlock(&thread->lock);
+
+    evpl_ring_doorbell(&thread->doorbell);
+} /* chimera_vfs_io_resume_post */
+
 static inline void
 chimera_vfs_post_to_delegation(
     struct chimera_vfs_request           *request,

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -176,6 +176,12 @@ chimera_vfs_request_alloc_common(
     request->cred   = cred;
     request->module = module;
 
+    /* Reset implicit-lease mediation state: requests are pooled and not
+     * fully memset on reuse, so a prior op's owner/pin must not leak in. */
+    request->io_owner_valid = 0;
+    request->io_next        = NULL;
+    request->io_lease_file  = NULL;
+
     if (fh && fhlen > 0) {
         memcpy(request->fh, fh, fhlen);
     }

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -179,6 +179,7 @@ chimera_vfs_request_alloc_common(
     /* Reset implicit-lease mediation state: requests are pooled and not
      * fully memset on reuse, so a prior op's owner/pin must not leak in. */
     request->io_owner_valid = 0;
+    request->io_recall_all  = 0;
     request->io_next        = NULL;
     request->io_lease_file  = NULL;
 

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+
+/*
+ * Unified VFS lease/lock vocabulary.
+ *
+ * These types are the lingua franca shared between the lease state layer
+ * (vfs_state.h) and the VFS request path (vfs.h), so they live in their own
+ * header to avoid an include cycle (vfs_state.h includes vfs.h).
+ */
+
+struct chimera_vfs_lease;
+struct chimera_vfs_file_state;
+
+/* -------------------------------------------------------------------- */
+/* Lease vocabulary                                                     */
+/* -------------------------------------------------------------------- */
+
+enum chimera_vfs_lease_kind {
+    CHIMERA_VFS_LEASE_RANGE   = 0, /* byte-range lock */
+    CHIMERA_VFS_LEASE_SHARE   = 1, /* whole-file share/deny reservation */
+    CHIMERA_VFS_LEASE_CACHING = 2, /* breakable caching lease */
+    CHIMERA_VFS_LEASE_KIND_MAX
+};
+
+/* Mode bits — SMB2 RWH triple, used as the lingua franca.
+ *   R = read-cache / shared range lock / SMB FILE_READ_DATA share-allow
+ *   W = write-cache / exclusive range lock / SMB FILE_WRITE_DATA share-allow
+ *   H = handle-cache (SMB only)
+ *   D = delete (SMB FILE_SHARE_DELETE)
+ *
+ * RANGE leases use {R} for shared, {W} for exclusive; H and D are ignored.
+ * SHARE leases use granted = access bits, denied = deny bits.
+ * CACHING leases use granted directly (e.g., {R,W,H} for an SMB lease).
+ */
+#define CHIMERA_VFS_LEASE_MODE_R         0x01
+#define CHIMERA_VFS_LEASE_MODE_W         0x02
+#define CHIMERA_VFS_LEASE_MODE_H         0x04
+#define CHIMERA_VFS_LEASE_MODE_D         0x08
+
+struct chimera_vfs_lease_mode {
+    uint8_t granted; /* bits the holder has been granted */
+    uint8_t denied;  /* SHARE only: bits this holder denies to others */
+};
+
+/* Protocol identifiers — used in owner.protocol so the conflict matrix
+ * can apply protocol-specific same-owner coalescing rules. */
+#define CHIMERA_VFS_LEASE_PROTO_NLM      1
+#define CHIMERA_VFS_LEASE_PROTO_NFSV4    2
+#define CHIMERA_VFS_LEASE_PROTO_SMB2     3
+/* Chimera itself, acquiring an implicit lease on behalf of an actor that
+ * does not (or cannot) request a protocol lease — e.g. an NFSv3 write, an
+ * S3 PUT, or NFSv4 data I/O through a plain stateid.  The lease is held by
+ * the server and is itself breakable (drained, then dropped) when another
+ * holder needs it or it goes idle. */
+#define CHIMERA_VFS_LEASE_PROTO_INTERNAL 4
+
+/* Break callback — invoked synchronously by vfs_state when this lease must
+ * downgrade or release.  The callback is expected to kick off the protocol-
+ * specific break (build SMB2 OPLOCK_BREAK, send NFSv4 CB_RECALL) and return
+ * promptly; vfs_state does not wait inside the callback.  The protocol
+ * server eventually calls chimera_vfs_lease_ack() (or chimera_vfs_lease_
+ * revoke() on its own timeout) to unstick the pending acquire. */
+typedef void (*chimera_vfs_lease_break_cb_t)(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data);
+
+/* Liveness probe — vfs_state calls this to test whether a lease's owning
+ * client/session is still considered alive.  Returns false on session
+ * expiry, connection drop past grace, etc.  May be NULL (always alive). */
+typedef bool (*chimera_vfs_lease_is_alive_cb_t)(
+    const struct chimera_vfs_lease *lease,
+    void                           *private_data);
+
+/* Revocation notice — vfs_state calls this when it forcibly revokes a lease
+ * (recall deadline elapsed, etc.) rather than the holder releasing it.  The
+ * protocol layer uses it to mark its own state revoked (e.g. so a later use of
+ * an NFSv4 delegation stateid reports NFS4ERR_DELEG_REVOKED).  May be NULL.
+ * Invoked outside the file lock. */
+typedef void (*chimera_vfs_lease_revoked_cb_t)(
+    struct chimera_vfs_lease *lease,
+    void                     *private_data);
+
+struct chimera_vfs_lease_owner {
+    uint32_t                        protocol;
+    uint64_t                        client_key;
+    uint64_t                        owner_lo;
+    uint64_t                        owner_hi;
+    chimera_vfs_lease_break_cb_t    break_cb;
+    chimera_vfs_lease_is_alive_cb_t is_alive_cb;
+    chimera_vfs_lease_revoked_cb_t  revoked_cb;
+    void                           *cb_private;
+};
+
+enum chimera_vfs_break_state {
+    CHIMERA_VFS_BREAK_IDLE     = 0, /* no break in progress */
+    CHIMERA_VFS_BREAK_BREAKING = 1, /* break_cb invoked, awaiting ack */
+    CHIMERA_VFS_BREAK_ACKED    = 2, /* protocol acked, lease downgraded */
+    CHIMERA_VFS_BREAK_REVOKED  = 3, /* forcibly revoked (timeout or error) */
+};
+
+struct chimera_vfs_lease {
+    enum chimera_vfs_lease_kind kind;
+    struct chimera_vfs_lease_mode  mode;
+    uint64_t                       offset; /* RANGE only; SHARE/CACHING use 0 */
+    uint64_t                       length; /* RANGE only; 0 = to EOF */
+    struct chimera_vfs_lease_owner owner;
+    struct chimera_vfs_file_state *file;
+
+    enum chimera_vfs_break_state break_state;
+    uint8_t                        break_needed_mode;
+    struct timespec                break_deadline;
+
+    /* For a SHARE probe only: a caching (handle) lease held under this same
+     * key is the requester's own lease (SMB2 same-client, same lease key) and
+     * must NOT be broken when acquiring the share — the opens coalesce.  Set by
+     * the SMB server when a lease-bearing open takes its share reservation;
+     * left zero (no skip) by every other caller. */
+    uint8_t                        has_break_skip_key;
+    uint64_t                       break_skip_lo;
+    uint64_t                       break_skip_hi;
+
+    /* Intrusive linkage on the appropriate file->{range,share,caching} list. */
+    struct chimera_vfs_lease      *prev;
+    struct chimera_vfs_lease      *next;
+};
+
+/* -------------------------------------------------------------------- */
+/* Lease result enum                                                    */
+/* -------------------------------------------------------------------- */
+
+/* Conflict-test result.  Returned by chimera_vfs_state_would_conflict(),
+ * chimera_vfs_state_try_insert(), and chimera_vfs_lease_test(). */
+enum chimera_vfs_lease_result {
+    CHIMERA_VFS_LEASE_GRANTED  = 0, /* no conflict; lease would be / was inserted */
+    CHIMERA_VFS_LEASE_DENIED   = 1, /* hard conflict with non-breakable holder */
+    CHIMERA_VFS_LEASE_BREAKING = 2, /* breakable holder must downgrade first */
+};
+
+/* -------------------------------------------------------------------- */
+/* Async-acquire ticket                                                 */
+/* -------------------------------------------------------------------- */
+
+/* Result of an async acquire.  GRANTED carries `granted_lease`; DENIED
+ * carries `conflict` (a pointer to a conflicting holder — owned by
+ * vfs_state, valid only until the callback returns). */
+typedef void (*chimera_vfs_lease_acquire_cb_t)(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted_lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data);
+
+/* Caller-allocated ticket holding pending-acquire bookkeeping.  Its
+ * lifetime must extend until the acquire callback fires.  Protocol
+ * layers typically embed this in their existing per-lock state struct
+ * (nlm_lock_entry, nfs4_state, smb_open_file's lock slot). */
+struct chimera_vfs_pending_acquire {
+    struct chimera_vfs_lease           *lease;
+    chimera_vfs_lease_acquire_cb_t      cb;
+    void                               *private_data;
+    struct chimera_vfs_file_state      *file;
+    bool                                queued;
+    struct chimera_vfs_pending_acquire *prev;
+    struct chimera_vfs_pending_acquire *next;
+};

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "vfs_procs.h"
+#include "vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_name_cache.h"
 #include "vfs_attr_cache.h"
@@ -108,5 +109,8 @@ chimera_vfs_link_at(
     request->proto_callback                      = callback;
     request->proto_private_data                  = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* RFC 7530 §10.4.5: adding a hard link to a delegated file must recall the
+     * delegation first.  request->fh is the source file being linked. */
+    chimera_vfs_io_recall(request, request->fh, request->fh_len,
+                          request->fh_hash, chimera_vfs_dispatch);
 } /* chimera_vfs_link_at */

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_open_cache.h"
 #include "vfs_attr_cache.h"
@@ -12,6 +13,10 @@ static void
 chimera_vfs_read_complete(struct chimera_vfs_request *request)
 {
     chimera_vfs_read_callback_t callback = request->proto_callback;
+
+    /* Release the implicit-lease pin taken before dispatch (no-op when none
+     * was taken). */
+    chimera_vfs_io_lease_release(request);
 
     /* Only refresh the attr cache when the caller actually requested stat
      * attributes (e.g. NFSv3 READ, which carries post_op_attr).  READ is
@@ -43,17 +48,18 @@ chimera_vfs_read_complete(struct chimera_vfs_request *request)
 } /* chimera_vfs_read_complete */
 
 SYMBOL_EXPORT void
-chimera_vfs_read(
-    struct chimera_vfs_thread      *thread,
-    const struct chimera_vfs_cred  *cred,
-    struct chimera_vfs_open_handle *handle,
-    uint64_t                        offset,
-    uint32_t                        count,
-    struct evpl_iovec              *iov,
-    int                             niov,
-    uint64_t                        attr_mask,
-    chimera_vfs_read_callback_t     callback,
-    void                           *private_data)
+chimera_vfs_read_owned(
+    struct chimera_vfs_thread            *thread,
+    const struct chimera_vfs_cred        *cred,
+    struct chimera_vfs_open_handle       *handle,
+    uint64_t                              offset,
+    uint32_t                              count,
+    struct evpl_iovec                    *iov,
+    int                                   niov,
+    uint64_t                              attr_mask,
+    const struct chimera_vfs_lease_owner *io_owner,
+    chimera_vfs_read_callback_t           callback,
+    void                                 *private_data)
 {
     struct chimera_vfs_request *request;
 
@@ -79,6 +85,25 @@ chimera_vfs_read(
     request->proto_callback          = callback;
     request->proto_private_data      = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* Mediate the read through the lease layer (acquire/hold the implicit
+     * lease for a leaseless actor, recalling another holder's conflicting
+     * write cache), then dispatch. */
+    chimera_vfs_io_lease_acquire(request, io_owner, chimera_vfs_dispatch);
+} /* chimera_vfs_read_owned */
 
-} /* chimera_vfs_write */
+SYMBOL_EXPORT void
+chimera_vfs_read(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        count,
+    struct evpl_iovec              *iov,
+    int                             niov,
+    uint64_t                        attr_mask,
+    chimera_vfs_read_callback_t     callback,
+    void                           *private_data)
+{
+    chimera_vfs_read_owned(thread, cred, handle, offset, count, iov, niov,
+                           attr_mask, NULL, callback, private_data);
+} /* chimera_vfs_read */

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 #include "vfs/vfs_internal.h"
 #include "vfs/vfs_name_cache.h"
 #include "vfs/vfs_attr_cache.h"
@@ -131,6 +132,10 @@ chimera_vfs_remove_at(
     request->proto_callback                        = callback;
     request->proto_private_data                    = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* Recall any delegation/oplock on the file being removed before unlinking
+     * it (the caller supplies its FH when known). */
+    chimera_vfs_io_recall(request, child_fh, child_fh_len,
+                          child_fh_len ? chimera_vfs_hash(child_fh, child_fh_len) : 0,
+                          chimera_vfs_dispatch);
 
 } /* chimera_vfs_remove_at */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "vfs_procs.h"
+#include "vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_name_cache.h"
 #include "vfs_notify.h"
@@ -143,5 +144,9 @@ chimera_vfs_rename_at(
     request->proto_callback                            = callback;
     request->proto_private_data                        = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* If the rename overwrites an existing destination, recall any
+     * delegation/oplock on that doomed file before it is replaced. */
+    chimera_vfs_io_recall(request, target_fh, target_fh_len,
+                          target_fh_len ? chimera_vfs_hash(target_fh, target_fh_len) : 0,
+                          chimera_vfs_dispatch);
 } /* chimera_vfs_rename_at */

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "vfs_procs.h"
+#include "vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_attr_cache.h"
 #include "common/misc.h"
@@ -65,5 +66,8 @@ chimera_vfs_setattr(
     request->proto_callback                  = callback;
     request->proto_private_data              = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* A metadata change invalidates any cached attributes a delegation/oplock
+    * holder has; recall every caching lease on the target before dispatch. */
+    chimera_vfs_io_recall(request, request->fh, request->fh_len,
+                          request->fh_hash, chimera_vfs_dispatch);
 } /* chimera_vfs_setattr */

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_open_cache.h"
 #include "vfs_attr_cache.h"
@@ -13,6 +14,9 @@ chimera_vfs_write_complete(struct chimera_vfs_request *request)
 {
     chimera_vfs_write_callback_t callback = request->proto_callback;
 
+    /* Release the implicit-lease pin taken before dispatch (no-op when none
+     * was taken). */
+    chimera_vfs_io_lease_release(request);
 
     if (request->status == CHIMERA_VFS_OK) {
         chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
@@ -35,19 +39,20 @@ chimera_vfs_write_complete(struct chimera_vfs_request *request)
 } /* chimera_vfs_write_complete */
 
 SYMBOL_EXPORT void
-chimera_vfs_write(
-    struct chimera_vfs_thread      *thread,
-    const struct chimera_vfs_cred  *cred,
-    struct chimera_vfs_open_handle *handle,
-    uint64_t                        offset,
-    uint32_t                        count,
-    uint32_t                        sync,
-    uint64_t                        pre_attr_mask,
-    uint64_t                        post_attr_mask,
-    struct evpl_iovec              *iov,
-    int                             niov,
-    chimera_vfs_write_callback_t    callback,
-    void                           *private_data)
+chimera_vfs_write_owned(
+    struct chimera_vfs_thread            *thread,
+    const struct chimera_vfs_cred        *cred,
+    struct chimera_vfs_open_handle       *handle,
+    uint64_t                              offset,
+    uint32_t                              count,
+    uint32_t                              sync,
+    uint64_t                              pre_attr_mask,
+    uint64_t                              post_attr_mask,
+    struct evpl_iovec                    *iov,
+    int                                   niov,
+    const struct chimera_vfs_lease_owner *io_owner,
+    chimera_vfs_write_callback_t          callback,
+    void                                 *private_data)
 {
     struct chimera_vfs_request *request;
 
@@ -73,7 +78,28 @@ chimera_vfs_write(
     request->proto_callback                = callback;
     request->proto_private_data            = private_data;
 
-    chimera_vfs_dispatch(request);
+    /* Mediate the write through the lease layer (acquire/hold the implicit
+     * lease for a leaseless actor, or break other holders' read caches for a
+     * lease-holding client), then dispatch. */
+    chimera_vfs_io_lease_acquire(request, io_owner, chimera_vfs_dispatch);
+} /* chimera_vfs_write_owned */
 
-
+SYMBOL_EXPORT void
+chimera_vfs_write(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        count,
+    uint32_t                        sync,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    struct evpl_iovec              *iov,
+    int                             niov,
+    chimera_vfs_write_callback_t    callback,
+    void                           *private_data)
+{
+    chimera_vfs_write_owned(thread, cred, handle, offset, count, sync,
+                            pre_attr_mask, post_attr_mask, iov, niov,
+                            NULL, callback, private_data);
 } /* chimera_vfs_write */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -439,6 +439,24 @@ chimera_vfs_read(
     chimera_vfs_read_callback_t     callback,
     void                           *private_data);
 
+/* As chimera_vfs_read(), but attributes the I/O to `io_owner` (a lease-
+ * holding client's owner) so its own delegation/oplock is not recalled by
+ * its own read.  Pass NULL to have chimera hold an implicit lease on behalf
+ * of a leaseless actor (equivalent to chimera_vfs_read()). */
+void
+chimera_vfs_read_owned(
+    struct chimera_vfs_thread            *thread,
+    const struct chimera_vfs_cred        *cred,
+    struct chimera_vfs_open_handle       *handle,
+    uint64_t                              offset,
+    uint32_t                              count,
+    struct evpl_iovec                    *iov,
+    int                                   niov,
+    uint64_t                              attrmask,
+    const struct chimera_vfs_lease_owner *io_owner,
+    chimera_vfs_read_callback_t           callback,
+    void                                 *private_data);
+
 typedef void (*chimera_vfs_write_callback_t)(
     enum chimera_vfs_error    error_code,
     uint32_t                  length,
@@ -461,6 +479,27 @@ chimera_vfs_write(
     int                             niov,
     chimera_vfs_write_callback_t    callback,
     void                           *private_data);
+
+/* As chimera_vfs_write(), but attributes the I/O to `io_owner` (a lease-
+ * holding client's owner) so its own write delegation/oplock is not recalled
+ * by its own write, while other holders' read caches are still invalidated.
+ * Pass NULL to have chimera hold an implicit lease on behalf of a leaseless
+ * actor (equivalent to chimera_vfs_write()). */
+void
+chimera_vfs_write_owned(
+    struct chimera_vfs_thread            *thread,
+    const struct chimera_vfs_cred        *cred,
+    struct chimera_vfs_open_handle       *handle,
+    uint64_t                              offset,
+    uint32_t                              count,
+    uint32_t                              sync,
+    uint64_t                              pre_attr_mask,
+    uint64_t                              post_attr_mask,
+    struct evpl_iovec                    *iov,
+    int                                   niov,
+    const struct chimera_vfs_lease_owner *io_owner,
+    chimera_vfs_write_callback_t          callback,
+    void                                 *private_data);
 
 typedef void (*chimera_vfs_commit_callback_t)(
     enum chimera_vfs_error    error_code,

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -18,6 +18,14 @@
 #define CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS 30000
 
 /*
+ * Implicit I/O leases held by chimera on behalf of leaseless actors are
+ * dropped once they have been idle (no in-flight I/O) for this long.  Keeps
+ * the resident per-file state bounded for write-once / read-once workloads
+ * while still letting bursts of I/O on the same file reuse a held lease.
+ */
+#define CHIMERA_VFS_STATE_DEFAULT_IMPLICIT_IDLE_MS  10000
+
+/*
  * NFSv4 delegation recall deadline.  A delegation being recalled keeps
  * conflicting acquirers waiting (NFS4ERR_DELAY); if the holder does not return
  * it within this window the server revokes it so other access can proceed.
@@ -36,6 +44,29 @@
  * operation can complete within a client's retry budget.
  */
 #define CHIMERA_VFS_NFS_DELEG_METAOP_MS             5000
+
+/* Retry every I/O request parked waiting for the implicit lease on `file`.
+ * Defined below; forward-declared so the break ack/revoke/remove paths can
+ * unblock parked I/O alongside protocol-lease acquires. */
+static void
+chimera_vfs_state_pump_io(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file);
+
+/* Milliseconds elapsed from `then` to `now` (both CLOCK_MONOTONIC).  Clamps
+ * to 0 if `now` precedes `then`. */
+static inline uint64_t
+chimera_vfs_elapsed_ms(
+    const struct timespec *then,
+    const struct timespec *now)
+{
+    if (now->tv_sec < then->tv_sec ||
+        (now->tv_sec == then->tv_sec && now->tv_nsec < then->tv_nsec)) {
+        return 0;
+    }
+    return (uint64_t) (now->tv_sec - then->tv_sec) * 1000ULL +
+           (uint64_t) (now->tv_nsec - then->tv_nsec) / 1000000ULL;
+} /* chimera_vfs_elapsed_ms */
 
 /* True if `lease`'s break deadline has elapsed (CLOCK_MONOTONIC). */
 static inline bool
@@ -71,6 +102,7 @@ chimera_vfs_state_init(void)
     }
 
     state->default_break_deadline_ms = CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS;
+    state->implicit_idle_ms          = CHIMERA_VFS_STATE_DEFAULT_IMPLICIT_IDLE_MS;
 
     return state;
 } /* chimera_vfs_state_init */
@@ -338,6 +370,38 @@ chimera_vfs_caching_conflict(
     return false;
 } /* chimera_vfs_caching_conflict */
 
+/* Evaluate a conflicting holder that the acquirer may be able to recall.
+ * A holder with a break_cb (e.g. chimera's own implicit I/O lease, an SMB
+ * oplock, an NFSv4 delegation) is recalled rather than failing the acquire:
+ * an IDLE holder is selected as the break victim; a holder already BREAKING
+ * keeps the acquirer waiting until its recall deadline elapses, after which
+ * it becomes revocable.  Returns true if the holder is NOT breakable, in
+ * which case the caller must hard-deny. */
+static inline bool
+chimera_vfs_eval_breakable(
+    struct chimera_vfs_lease  *cur,
+    bool                      *has_breakable,
+    struct chimera_vfs_lease **idle_break,
+    struct chimera_vfs_lease **expired_break)
+{
+    if (!cur->owner.break_cb) {
+        return true;
+    }
+
+    if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+        *has_breakable = true;
+        if (!*idle_break) {
+            *idle_break = cur;
+        }
+    } else if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+        *has_breakable = true;
+        if (!*expired_break && chimera_vfs_break_deadline_passed(cur)) {
+            *expired_break = cur;
+        }
+    }
+    return false;
+} /* chimera_vfs_eval_breakable */
+
 SYMBOL_EXPORT enum chimera_vfs_lease_result
 chimera_vfs_state_would_conflict(
     const struct chimera_vfs_file_state *file,
@@ -411,11 +475,23 @@ chimera_vfs_state_would_conflict(
             break;
 
         case CHIMERA_VFS_LEASE_SHARE:
+        {
+            struct chimera_vfs_lease *idle_break    = NULL;
+            struct chimera_vfs_lease *expired_break = NULL;
+
             for (cur = file->share_resvs; cur; cur = cur->next) {
                 if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
                     continue;
                 }
-                if (chimera_vfs_share_conflict(cur, probe)) {
+                if (!chimera_vfs_share_conflict(cur, probe)) {
+                    continue;
+                }
+                /* A breakable share holder is chimera's own implicit I/O
+                 * lease: recall it so a real client open can take the file.
+                 * A non-breakable holder is an ordinary client open and is a
+                 * hard share conflict. */
+                if (chimera_vfs_eval_breakable(cur, &has_breakable_conflict,
+                                               &idle_break, &expired_break)) {
                     if (conflict_out) {
                         *conflict_out = cur;
                     }
@@ -432,90 +508,86 @@ chimera_vfs_state_would_conflict(
              *     delegation (W) by any other open.  Limiting the R/W rule to
              *     NFSv4-owned leases keeps SMB oplock/lease break semantics
              *     unchanged (those run through the CACHING-vs-CACHING path). */
-            {
-                struct chimera_vfs_lease *idle_break    = NULL;
-                struct chimera_vfs_lease *expired_break = NULL;
+            for (cur = file->caching_leases; cur; cur = cur->next) {
+                bool want_break_h   = false;
+                bool want_break_nfs = false;
 
-                for (cur = file->caching_leases; cur; cur = cur->next) {
-                    bool want_break_h   = false;
-                    bool want_break_nfs = false;
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    continue;
+                }
+                /* Same client + same lease key: the requester's own lease
+                 * (a second open under one lease key). It coalesces; do
+                 * not break it. */
+                if (probe->has_break_skip_key &&
+                    cur->owner.owner_lo == probe->break_skip_lo &&
+                    cur->owner.owner_hi == probe->break_skip_hi) {
+                    continue;
+                }
+                if (!cur->owner.break_cb) {
+                    continue;
+                }
 
-                    if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
-                        continue;
+                if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) {
+                    want_break_h = true;
+                }
+
+                if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
+                    cur->owner.client_key != probe->owner.client_key) {
+                    /* A client never recalls its own delegation; recall is
+                     * for conflicting access by *other* clients. */
+                    uint8_t g  = cur->mode.granted;
+                    uint8_t pg = probe->mode.granted;
+                    uint8_t pd = probe->mode.denied;
+
+                    if ((g & CHIMERA_VFS_LEASE_MODE_W) &&
+                        (pg & (CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W))) {
+                        want_break_nfs = true; /* write deleg vs any open */
                     }
-                    /* Same client + same lease key: the requester's own lease
-                     * (a second open under one lease key). It coalesces; do
-                     * not break it. */
-                    if (probe->has_break_skip_key &&
-                        cur->owner.owner_lo == probe->break_skip_lo &&
-                        cur->owner.owner_hi == probe->break_skip_hi) {
-                        continue;
+                    if ((g & CHIMERA_VFS_LEASE_MODE_R) &&
+                        (pg & CHIMERA_VFS_LEASE_MODE_W)) {
+                        want_break_nfs = true; /* read deleg vs writer */
                     }
-                    if (!cur->owner.break_cb) {
-                        continue;
+                    if (pd & g) {
+                        want_break_nfs = true; /* deny clashes with cache */
                     }
+                }
 
-                    if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) {
-                        want_break_h = true;
+                /* SMB handle-cache: break only an IDLE holder (existing
+                * optimistic-after-break semantics retained for SMB). */
+                if (want_break_h &&
+                    cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                    has_breakable_conflict = true;
+                    if (!idle_break) {
+                        idle_break = cur;
                     }
+                }
 
-                    if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
-                        cur->owner.client_key != probe->owner.client_key) {
-                        /* A client never recalls its own delegation; recall is
-                         * for conflicting access by *other* clients. */
-                        uint8_t g  = cur->mode.granted;
-                        uint8_t pg = probe->mode.granted;
-                        uint8_t pd = probe->mode.denied;
-
-                        if ((g & CHIMERA_VFS_LEASE_MODE_W) &&
-                            (pg & (CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W))) {
-                            want_break_nfs = true; /* write deleg vs any open */
-                        }
-                        if ((g & CHIMERA_VFS_LEASE_MODE_R) &&
-                            (pg & CHIMERA_VFS_LEASE_MODE_W)) {
-                            want_break_nfs = true; /* read deleg vs writer */
-                        }
-                        if (pd & g) {
-                            want_break_nfs = true; /* deny clashes with cache */
-                        }
-                    }
-
-                    /* SMB handle-cache: break only an IDLE holder (existing
-                    * optimistic-after-break semantics retained for SMB). */
-                    if (want_break_h &&
-                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                /* NFSv4 delegation: a holder that is still IDLE must be
+                 * recalled; one already BREAKING keeps the acquirer waiting
+                 * (do NOT grant conflicting access mid-recall) until it
+                 * returns the delegation or its recall deadline elapses, at
+                 * which point it becomes revocable. */
+                if (want_break_nfs) {
+                    if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
                         has_breakable_conflict = true;
                         if (!idle_break) {
                             idle_break = cur;
                         }
-                    }
-
-                    /* NFSv4 delegation: a holder that is still IDLE must be
-                     * recalled; one already BREAKING keeps the acquirer waiting
-                     * (do NOT grant conflicting access mid-recall) until it
-                     * returns the delegation or its recall deadline elapses, at
-                     * which point it becomes revocable. */
-                    if (want_break_nfs) {
-                        if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
-                            has_breakable_conflict = true;
-                            if (!idle_break) {
-                                idle_break = cur;
-                            }
-                        } else if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
-                            has_breakable_conflict = true;
-                            if (!expired_break &&
-                                chimera_vfs_break_deadline_passed(cur)) {
-                                expired_break = cur;
-                            }
+                    } else if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                        has_breakable_conflict = true;
+                        if (!expired_break &&
+                            chimera_vfs_break_deadline_passed(cur)) {
+                            expired_break = cur;
                         }
                     }
                 }
-
-                if (conflict_out && !*conflict_out) {
-                    *conflict_out = idle_break ? idle_break : expired_break;
-                }
             }
-            break;
+
+            if (conflict_out && !*conflict_out) {
+                *conflict_out = idle_break ? idle_break : expired_break;
+            }
+        }
+        break;
 
         case CHIMERA_VFS_LEASE_CACHING:
             for (cur = file->caching_leases; cur; cur = cur->next) {
@@ -544,6 +616,9 @@ chimera_vfs_state_would_conflict(
              * (SMB caching leases use the caching-vs-caching path above, so
              * this NFSv4-only check leaves them unaffected.) */
             if (probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4) {
+                struct chimera_vfs_lease *idle_break    = NULL;
+                struct chimera_vfs_lease *expired_break = NULL;
+
                 for (cur = file->share_resvs; cur; cur = cur->next) {
                     uint8_t sg = cur->mode.granted;
                     bool conflict;
@@ -557,12 +632,24 @@ chimera_vfs_state_would_conflict(
                     } else {
                         conflict = (sg & CHIMERA_VFS_LEASE_MODE_W) != 0;
                     }
-                    if (conflict) {
+                    if (!conflict) {
+                        continue;
+                    }
+                    /* A breakable share holder (chimera's implicit I/O lease)
+                     * is recalled so the delegation can be granted once the
+                     * in-flight I/O drains; a real client open is a hard
+                     * conflict that denies the delegation. */
+                    if (chimera_vfs_eval_breakable(cur, &has_breakable_conflict,
+                                                   &idle_break, &expired_break)) {
                         if (conflict_out) {
                             *conflict_out = cur;
                         }
                         return CHIMERA_VFS_LEASE_DENIED;
                     }
+                }
+
+                if (conflict_out && !*conflict_out) {
+                    *conflict_out = idle_break ? idle_break : expired_break;
                 }
             }
             break;
@@ -824,8 +911,9 @@ chimera_vfs_state_remove(
     chimera_vfs_file_state_remove_lease(file, lease);
     pthread_mutex_unlock(&file->lock);
 
-    /* Removing a lease may unblock a pending acquire. */
+    /* Removing a lease may unblock a pending acquire or a parked I/O. */
     chimera_vfs_state_pump_pending(state, file);
+    chimera_vfs_state_pump_io(state, file);
 } /* chimera_vfs_state_remove */
 
 /* -------------------------------------------------------------------- */
@@ -1045,9 +1133,10 @@ chimera_vfs_lease_ack(
         pthread_mutex_unlock(&file->lock);
     }
 
-    /* Acking a break may unblock pending acquires. */
+    /* Acking a break may unblock pending acquires or parked I/O. */
     if (mutated && file && file->state) {
         chimera_vfs_state_pump_pending(file->state, file);
+        chimera_vfs_state_pump_io(file->state, file);
     }
 } /* chimera_vfs_lease_ack */
 
@@ -1079,9 +1168,10 @@ chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
         revoked_cb(lease, cb_private);
     }
 
-    /* Revoking a lease may unblock pending acquires. */
+    /* Revoking a lease may unblock pending acquires or parked I/O. */
     if (file && file->state) {
         chimera_vfs_state_pump_pending(file->state, file);
+        chimera_vfs_state_pump_io(file->state, file);
     }
 } /* chimera_vfs_lease_revoke */
 
@@ -1157,15 +1247,8 @@ chimera_vfs_state_break_caching(
 } /* chimera_vfs_state_break_caching */
 
 /* -------------------------------------------------------------------- */
-/* I/O hook (no-op for Stage A)                                         */
+/* Break-on-write                                                       */
 /* -------------------------------------------------------------------- */
-
-SYMBOL_EXPORT int
-chimera_vfs_state_check_io(struct chimera_vfs_request *request)
-{
-    (void) request;
-    return 0;
-} /* chimera_vfs_state_check_io */
 
 /* Upper bound on caching leases broken by a single write.  A file with
  * more concurrent caching holders than this is pathological; any excess
@@ -1183,25 +1266,18 @@ chimera_vfs_state_check_io(struct chimera_vfs_request *request)
  * Breaks are dispatched via begin_break with needed_mode==0, which the
  * SMB break callback interprets as "break to NONE" (the open-conflict
  * path always passes a non-zero retained mask, so 0 is an unambiguous
- * write-invalidation signal). */
-SYMBOL_EXPORT void
-chimera_vfs_state_break_on_write(
+ * write-invalidation signal).  Inner form: caller holds a reference on
+ * `file`. */
+static void
+chimera_vfs_break_reads_for_write(
     struct chimera_vfs_state             *state,
-    const uint8_t                        *fh,
-    uint8_t                               fh_len,
-    uint64_t                              fh_hash,
+    struct chimera_vfs_file_state        *file,
     const struct chimera_vfs_lease_owner *writer)
 {
-    struct chimera_vfs_file_state *file;
-    struct chimera_vfs_lease      *cur;
-    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
-    int                            n = 0;
-    int                            i;
-
-    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
-    if (!file) {
-        return;
-    }
+    struct chimera_vfs_lease *cur;
+    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                       n = 0;
+    int                       i;
 
     pthread_mutex_lock(&file->lock);
 
@@ -1223,6 +1299,464 @@ chimera_vfs_state_break_on_write(
     for (i = 0; i < n; i++) {
         chimera_vfs_lease_begin_break(state, to_break[i], 0, 0);
     }
+} /* chimera_vfs_break_reads_for_write */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_break_on_write(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *writer)
+{
+    struct chimera_vfs_file_state *file;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    chimera_vfs_break_reads_for_write(state, file, writer);
 
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
+
+/* -------------------------------------------------------------------- */
+/* Implicit I/O lease                                                   */
+/* -------------------------------------------------------------------- */
+
+/*
+ * The VFS core holds an implicit lease on behalf of actors that perform
+ * I/O without requesting a protocol lease (NFSv3, S3, NFSv4 data I/O).
+ * The lease is a deny-nothing SHARE registered on the file's share list
+ * under a chimera-internal owner.  It is *cached*: kept across operations
+ * and dropped only when it goes idle (chimera_vfs_state_reap_idle) or when
+ * another holder recalls it (chimera_vfs_implicit_break_cb).  Each in-flight
+ * I/O pins it (implicit_inflight); a recall waits for the pin count to drain
+ * before the lease is dropped.  Modeling it as a deny=0 SHARE means two
+ * independent leaseless writers never serialize against each other, yet a
+ * write-share still recalls another client's conflicting delegation/oplock
+ * and a real client open can recall the implicit lease in turn.
+ */
+
+static void
+chimera_vfs_implicit_break_cb(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data);
+
+static void
+chimera_vfs_implicit_finish_drain(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file);
+
+static void
+chimera_vfs_io_resume(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_request    *request);
+
+/* Deterministic per-file owner for chimera's implicit lease.  protocol==
+ * INTERNAL and client_key==0 distinguish it from every real client owner,
+ * so it never coalesces with (and thus always recalls / is recalled by) a
+ * client's delegation, oplock, or deny-mode open. */
+static void
+chimera_vfs_implicit_owner(
+    struct chimera_vfs_file_state  *file,
+    struct chimera_vfs_lease_owner *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->protocol   = CHIMERA_VFS_LEASE_PROTO_INTERNAL;
+    out->client_key = 0;
+    out->owner_lo   = file->fh_hash;
+    out->owner_hi   = 0;
+    out->break_cb   = chimera_vfs_implicit_break_cb;
+    out->cb_private = file->state;
+} /* chimera_vfs_implicit_owner */
+
+/* Recall callback for the implicit lease: a conflicting holder needs the
+ * file.  Stop admitting new I/O (implicit_draining) and, once the in-flight
+ * pins drain, drop the lease.  Invoked outside file->lock by begin_break. */
+static void
+chimera_vfs_implicit_break_cb(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data)
+{
+    struct chimera_vfs_state      *state = private_data;
+    struct chimera_vfs_file_state *file  = lease->file;
+    bool                           drop_now;
+
+    (void) needed_mode;
+
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    file->implicit_draining = 1;
+    drop_now                = (file->implicit_inflight == 0);
+    pthread_mutex_unlock(&file->lock);
+
+    if (drop_now) {
+        chimera_vfs_implicit_finish_drain(state, file);
+    }
+    /* Otherwise the last chimera_vfs_io_lease_release() finishes the drain. */
+} /* chimera_vfs_implicit_break_cb */
+
+/* Remove the (drained) implicit lease and release the reference it held on
+ * the file state.  Idempotent across the racing release / break_cb callers
+ * via the implicit_active guard.  Pumps both wait queues so a recaller and
+ * any parked I/O re-evaluate. */
+static void
+chimera_vfs_implicit_finish_drain(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
+{
+    bool removed = false;
+
+    pthread_mutex_lock(&file->lock);
+    if (file->implicit_active) {
+        chimera_vfs_file_state_remove_lease(file, &file->implicit_lease);
+        file->implicit_active            = 0;
+        file->implicit_lease.break_state = CHIMERA_VFS_BREAK_IDLE;
+        removed                          = true;
+    }
+    file->implicit_draining = 0;
+    pthread_mutex_unlock(&file->lock);
+
+    if (removed) {
+        chimera_vfs_state_pump_pending(state, file);
+        chimera_vfs_state_pump_io(state, file);
+        /* Drop the reference the lease itself held (taken at activation). */
+        chimera_vfs_state_put(state, file);
+    }
+} /* chimera_vfs_implicit_finish_drain */
+
+/* Drive begin_break / revoke on every breakable holder conflicting with
+ * `probe` until none remain IDLE, mirroring the loop in
+ * chimera_vfs_state_try_insert().  Returns the final would_conflict result:
+ * GRANTED once all conflicts have cleared, DENIED on a non-breakable
+ * holder, or BREAKING if holders are still mid-recall (caller parks).
+ * Caller must NOT hold file->lock. */
+static enum chimera_vfs_lease_result
+chimera_vfs_state_drive_breaks(
+    struct chimera_vfs_state       *state,
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *probe)
+{
+    struct chimera_vfs_lease     *conflict = NULL;
+    enum chimera_vfs_lease_result result;
+
+    pthread_mutex_lock(&file->lock);
+    result = chimera_vfs_state_would_conflict(file, probe, &conflict);
+    pthread_mutex_unlock(&file->lock);
+
+    while (result == CHIMERA_VFS_LEASE_BREAKING && conflict) {
+        if (conflict->break_state == CHIMERA_VFS_BREAK_IDLE) {
+            uint32_t deadline_ms =
+                (conflict->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4)
+                ? CHIMERA_VFS_NFS_DELEG_RECALL_MS : 0;
+            chimera_vfs_lease_begin_break(state, conflict,
+                                          probe->mode.granted, deadline_ms);
+        } else {
+            chimera_vfs_lease_revoke(conflict);
+        }
+        conflict = NULL;
+        pthread_mutex_lock(&file->lock);
+        result = chimera_vfs_state_would_conflict(file, probe, &conflict);
+        pthread_mutex_unlock(&file->lock);
+    }
+
+    return result;
+} /* chimera_vfs_state_drive_breaks */
+
+/* Park `request` on the file's I/O wait queue.  Caller holds file->lock. */
+static void
+chimera_vfs_io_park_locked(
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_request    *request)
+{
+    struct chimera_vfs_pending_acquire *ticket = &request->io_lease_ticket;
+
+    ticket->lease        = NULL;
+    ticket->cb           = NULL;
+    ticket->private_data = request;
+    ticket->file         = file;
+    ticket->queued       = true;
+    ticket->next         = NULL;
+    ticket->prev         = file->io_wait_tail;
+
+    if (file->io_wait_tail) {
+        file->io_wait_tail->next = ticket;
+    } else {
+        file->io_wait_head = ticket;
+    }
+    file->io_wait_tail = ticket;
+} /* chimera_vfs_io_park_locked */
+
+/* Forward decl: io_try and pump_io are mutually recursive (a synchronous
+ * conflict-clear in io_try pumps the queue, which re-runs io_try). */
+static void
+chimera_vfs_io_try(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_request    *request);
+
+/* Retry every parked I/O request. */
+static void
+chimera_vfs_state_pump_io(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_pending_acquire *head, *t, *next;
+
+    pthread_mutex_lock(&file->lock);
+    head               = file->io_wait_head;
+    file->io_wait_head = NULL;
+    file->io_wait_tail = NULL;
+    for (t = head; t; t = t->next) {
+        t->queued = false;
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    for (t = head; t; t = next) {
+        struct chimera_vfs_request *request = t->private_data;
+
+        next    = t->next;
+        t->prev = NULL;
+        t->next = NULL;
+
+        chimera_vfs_io_try(state, file, request);
+    }
+} /* chimera_vfs_state_pump_io */
+
+/* Acquire / upgrade the implicit lease for `request` and either proceed
+ * (io_next), park (to be retried by pump_io), or fail.  `file` carries the
+ * request's in-flight reference (taken at acquire entry, released by
+ * chimera_vfs_io_lease_release on the proceed/park paths, or dropped here on
+ * the fail path).  Parking happens under the same lock that observes the
+ * conflict, so a concurrent ack / finish_drain that pumps the queue cannot
+ * lose the wakeup. */
+static void
+chimera_vfs_io_try(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_request    *request)
+{
+    struct chimera_vfs_lease      probe;
+    struct chimera_vfs_lease     *conflict = NULL;
+    enum chimera_vfs_lease_result result;
+    uint8_t                       need;
+    uint8_t                       target;
+    bool                          was_active;
+    bool                          activated = false;
+
+    need = (request->opcode == CHIMERA_VFS_OP_WRITE)
+        ? CHIMERA_VFS_LEASE_MODE_W : CHIMERA_VFS_LEASE_MODE_R;
+
+    pthread_mutex_lock(&file->lock);
+
+    if (file->implicit_draining) {
+        /* A recall of our own lease is draining; wait for it to finish, then
+         * finish_drain will pump us to re-acquire fresh. */
+        chimera_vfs_io_park_locked(file, request);
+        request->io_lease_file = file;
+        pthread_mutex_unlock(&file->lock);
+        return;
+    }
+
+    was_active = file->implicit_active;
+    target     = was_active
+        ? (uint8_t) (file->implicit_lease.mode.granted | need)
+        : need;
+
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_SHARE;
+    probe.mode.granted = target;
+    probe.mode.denied  = 0;
+    chimera_vfs_implicit_owner(file, &probe.owner);
+
+    result = chimera_vfs_state_would_conflict(file, &probe, &conflict);
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        if (!was_active) {
+            file->implicit_lease             = probe;
+            file->implicit_lease.break_state = CHIMERA_VFS_BREAK_IDLE;
+            chimera_vfs_file_state_insert_lease(file, &file->implicit_lease);
+            file->implicit_active = 1;
+            activated             = true;
+        } else {
+            file->implicit_lease.mode.granted = target;
+        }
+        file->implicit_inflight++;
+        clock_gettime(CLOCK_MONOTONIC, &file->implicit_last_used);
+        pthread_mutex_unlock(&file->lock);
+
+        if (activated) {
+            /* Reference for the lease itself, dropped by finish_drain. */
+            chimera_vfs_state_get(state, file->fh, file->fh_len,
+                                  file->fh_hash, false);
+        }
+
+        request->io_lease_file = file;
+        if (need == CHIMERA_VFS_LEASE_MODE_W) {
+            struct chimera_vfs_lease_owner iowner;
+            chimera_vfs_implicit_owner(file, &iowner);
+            chimera_vfs_break_reads_for_write(state, file, &iowner);
+        }
+        request->io_next(request);
+        return;
+    }
+
+    if (result == CHIMERA_VFS_LEASE_DENIED) {
+        pthread_mutex_unlock(&file->lock);
+        request->io_lease_file = NULL;
+        chimera_vfs_state_put(state, file);
+        request->status = CHIMERA_VFS_EACCES;
+        request->complete(request);
+        return;
+    }
+
+    /* BREAKING: park atomically with the conflict observation, then drive the
+     * recalls outside the lock. */
+    chimera_vfs_io_park_locked(file, request);
+    request->io_lease_file = file;
+    pthread_mutex_unlock(&file->lock);
+
+    if (chimera_vfs_state_drive_breaks(state, file, &probe) !=
+        CHIMERA_VFS_LEASE_BREAKING) {
+        /* The conflict cleared synchronously (the breakable holder was
+         * removed/revoked rather than going to an async recall); retry the
+         * parked waiters now.  Otherwise an async recall is in flight and its
+         * ack/revoke will pump us. */
+        chimera_vfs_state_pump_io(state, file);
+    }
+} /* chimera_vfs_io_try */
+
+SYMBOL_EXPORT void
+chimera_vfs_io_lease_acquire(
+    struct chimera_vfs_request           *request,
+    const struct chimera_vfs_lease_owner *owner,
+    void (                               *next )(struct chimera_vfs_request *request))
+{
+    struct chimera_vfs_state      *state = request->thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *file;
+
+    request->io_next       = next;
+    request->io_lease_file = NULL;
+
+    /* A lease-holding client (NFSv4 delegation, SMB oplock) supplies its own
+     * owner: it already registered its lease at open time, so per-I/O we
+     * only invalidate other holders' read caches on a write.  No implicit
+     * lease is held on its behalf. */
+    if (owner) {
+        if (request->opcode == CHIMERA_VFS_OP_WRITE) {
+            chimera_vfs_state_break_on_write(state, request->fh,
+                                             request->fh_len, request->fh_hash,
+                                             owner);
+        }
+        next(request);
+        return;
+    }
+
+    if (!state) {
+        next(request);
+        return;
+    }
+
+    /* Leaseless actor: chimera holds an implicit lease on its behalf.  The
+     * reference taken here is carried by the request until release. */
+    file = chimera_vfs_state_get(state, request->fh, request->fh_len,
+                                 request->fh_hash, true);
+    if (!file) {
+        next(request);
+        return;
+    }
+
+    chimera_vfs_io_try(state, file, request);
+} /* chimera_vfs_io_lease_acquire */
+
+SYMBOL_EXPORT void
+chimera_vfs_io_lease_release(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file = request->io_lease_file;
+    bool                           finish;
+
+    if (!file) {
+        return; /* fast path / lease-holding client: nothing pinned */
+    }
+
+    request->io_lease_file = NULL;
+    state                  = request->thread->vfs->vfs_state;
+
+    pthread_mutex_lock(&file->lock);
+    if (file->implicit_inflight > 0) {
+        file->implicit_inflight--;
+    }
+    finish = (file->implicit_inflight == 0 &&
+              file->implicit_draining &&
+              file->implicit_active);
+    pthread_mutex_unlock(&file->lock);
+
+    if (finish) {
+        chimera_vfs_implicit_finish_drain(state, file);
+    }
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_io_lease_release */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_reap_idle(
+    struct chimera_vfs_state *state,
+    uint64_t                  idle_ms)
+{
+#define CHIMERA_VFS_STATE_REAP_BATCH 64
+    struct timespec now;
+    int             b;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    for (b = 0; b < CHIMERA_VFS_STATE_NUM_BUCKETS; b++) {
+        struct chimera_vfs_state_bucket *bucket = &state->buckets[b];
+        struct chimera_vfs_file_state   *cand[CHIMERA_VFS_STATE_REAP_BATCH];
+        struct chimera_vfs_file_state   *file;
+        int                              n = 0;
+        int                              i;
+
+        pthread_mutex_lock(&bucket->lock);
+        for (file = bucket->files;
+             file && n < CHIMERA_VFS_STATE_REAP_BATCH;
+             file = file->bucket_next) {
+            if (file->implicit_active) {
+                file->refcount++;
+                cand[n++] = file;
+            }
+        }
+        pthread_mutex_unlock(&bucket->lock);
+
+        for (i = 0; i < n; i++) {
+            bool reapable;
+
+            file = cand[i];
+
+            pthread_mutex_lock(&file->lock);
+            reapable = file->implicit_active &&
+                !file->implicit_draining &&
+                file->implicit_inflight == 0 &&
+                chimera_vfs_elapsed_ms(&file->implicit_last_used, &now) >= idle_ms;
+            if (reapable) {
+                file->implicit_draining = 1;
+            }
+            pthread_mutex_unlock(&file->lock);
+
+            if (reapable) {
+                chimera_vfs_implicit_finish_drain(state, file);
+            }
+
+            chimera_vfs_state_put(state, file);
+        }
+    }
+#undef CHIMERA_VFS_STATE_REAP_BATCH
+} /* chimera_vfs_state_reap_idle */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1528,21 +1528,28 @@ chimera_vfs_io_park_locked(
     file->io_wait_tail = ticket;
 } /* chimera_vfs_io_park_locked */
 
-/* Forward decl: io_try and pump_io are mutually recursive (a synchronous
- * conflict-clear in io_try pumps the queue, which re-runs io_try). */
+/* Forward decl: chimera_vfs_state_io_resume() and io_try's synchronous
+ * conflict-clear path both reach io_try, which is defined below. */
 static void
 chimera_vfs_io_try(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file,
     struct chimera_vfs_request    *request);
 
-/* Retry every parked I/O request. */
+/* Retry every parked I/O request.  The pump can run on any thread (lease
+ * release, break ack/revoke, or the idle reaper), so each request is
+ * marshaled back to its owning thread (chimera_vfs_io_resume_post) rather than
+ * resumed inline: its dispatch and reply must run on request->thread, whose
+ * connection iovecs are thread-local.  chimera_vfs_state_io_resume() then
+ * re-runs io_try on the owning thread. */
 static void
 chimera_vfs_state_pump_io(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file)
 {
     struct chimera_vfs_pending_acquire *head, *t, *next;
+
+    (void) state;
 
     pthread_mutex_lock(&file->lock);
     head               = file->io_wait_head;
@@ -1560,9 +1567,23 @@ chimera_vfs_state_pump_io(
         t->prev = NULL;
         t->next = NULL;
 
-        chimera_vfs_io_try(state, file, request);
+        chimera_vfs_io_resume_post(request);
     }
 } /* chimera_vfs_state_pump_io */
+
+/* Resume a parked I/O request on its owning thread (called from that thread's
+ * doorbell drain).  The request carries the pinned file in io_lease_file. */
+SYMBOL_EXPORT void
+chimera_vfs_state_io_resume(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_file_state *file = request->io_lease_file;
+
+    if (!file) {
+        return;
+    }
+
+    chimera_vfs_io_try(request->thread->vfs->vfs_state, file, request);
+} /* chimera_vfs_state_io_resume */
 
 /* Acquire / upgrade the implicit lease for `request` and either proceed
  * (io_next), park (to be retried by pump_io), or fail.  `file` carries the

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1204,6 +1204,18 @@ chimera_vfs_break_caching_file(
                 to_break = cur;
                 break;
             }
+            /* A holder that already acked an earlier break but still retains a
+             * mode (an SMB lease downgraded to LEVEL_II, granted=R, ACKED) must
+             * be re-armed and broken again — a namespace/metadata mutation
+             * needs the cache gone entirely.  Reset to IDLE so begin_break
+             * re-fires it to NONE.  (NFSv4 delegations never sit ACKED with a
+             * retained mode — they return to NONE or are revoked — so this
+             * only affects SMB read caches.) */
+            if (cur->break_state == CHIMERA_VFS_BREAK_ACKED) {
+                cur->break_state = CHIMERA_VFS_BREAK_IDLE;
+                to_break         = cur;
+                break;
+            }
             if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
                 chimera_vfs_break_deadline_passed(cur)) {
                 to_revoke = cur;
@@ -1213,8 +1225,14 @@ chimera_vfs_break_caching_file(
         pthread_mutex_unlock(&file->lock);
 
         if (to_break) {
-            chimera_vfs_lease_begin_break(state, to_break,
-                                          to_break->mode.granted,
+            /* Break to NONE (needed_mode 0), not to the currently-granted
+             * mode: a namespace/metadata mutation invalidates the holder's
+             * cache entirely.  Passing the granted mode would let the SMB
+             * lease break_cb retain its read cache (LEVEL_II) and ack with a
+             * non-zero mode, so this loop would see granted != 0 forever and
+             * the caller would park permanently.  NFSv4 delegations recall
+             * fully regardless of needed_mode, so 0 is correct for them too. */
+            chimera_vfs_lease_begin_break(state, to_break, 0,
                                           CHIMERA_VFS_NFS_DELEG_METAOP_MS);
         } else if (to_revoke) {
             chimera_vfs_lease_revoke(to_revoke);

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1175,20 +1175,15 @@ chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
     }
 } /* chimera_vfs_lease_revoke */
 
-SYMBOL_EXPORT bool
-chimera_vfs_state_break_caching(
-    struct chimera_vfs_state *state,
-    const uint8_t            *fh,
-    uint8_t                   fh_len,
-    uint64_t                  fh_hash)
+/* Recall every caching lease on `file`, regardless of owner.  Caller holds a
+ * reference on `file`.  Returns true if any caching holder still retains a
+ * granted mode (the recall is in flight; caller should wait/retry). */
+static bool
+chimera_vfs_break_caching_file(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
 {
-    struct chimera_vfs_file_state *file;
-    bool                           had;
-
-    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
-    if (!file) {
-        return false;
-    }
+    bool had;
 
     /* Drive each caching holder forward: recall a still-IDLE holder, and
      * revoke a holder whose recall deadline has elapsed (never returned).
@@ -1241,6 +1236,26 @@ chimera_vfs_state_break_caching(
         }
     }
     pthread_mutex_unlock(&file->lock);
+
+    return had;
+} /* chimera_vfs_break_caching_file */
+
+SYMBOL_EXPORT bool
+chimera_vfs_state_break_caching(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash)
+{
+    struct chimera_vfs_file_state *file;
+    bool                           had;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return false;
+    }
+
+    had = chimera_vfs_break_caching_file(state, file);
 
     chimera_vfs_state_put(state, file);
     return had;
@@ -1552,6 +1567,25 @@ chimera_vfs_io_try(
     bool                          was_active;
     bool                          activated = false;
 
+    /* Namespace/metadata mutation: recall every caching lease on the target
+     * file (regardless of owner — RFC 7530 §10.4.5 requires recalling even
+     * the operating client's own delegation), then proceed.  No lease is held
+     * on chimera's behalf.  The periodic maintenance pass re-pumps parked
+     * waiters so an unresponsive holder is revoked at its recall deadline. */
+    if (request->io_recall_all) {
+        if (chimera_vfs_break_caching_file(state, file)) {
+            pthread_mutex_lock(&file->lock);
+            chimera_vfs_io_park_locked(file, request);
+            request->io_lease_file = file;
+            pthread_mutex_unlock(&file->lock);
+            return;
+        }
+        request->io_lease_file = NULL;
+        chimera_vfs_state_put(state, file);
+        request->io_next(request);
+        return;
+    }
+
     need = (request->opcode == CHIMERA_VFS_OP_WRITE)
         ? CHIMERA_VFS_LEASE_MODE_W : CHIMERA_VFS_LEASE_MODE_R;
 
@@ -1678,6 +1712,36 @@ chimera_vfs_io_lease_acquire(
 } /* chimera_vfs_io_lease_acquire */
 
 SYMBOL_EXPORT void
+chimera_vfs_io_recall(
+    struct chimera_vfs_request *request,
+    const uint8_t              *fh,
+    uint8_t                     fh_len,
+    uint64_t                    fh_hash,
+    void (                     *next )(struct chimera_vfs_request *request))
+{
+    struct chimera_vfs_state      *state = request->thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *file;
+
+    request->io_next       = next;
+    request->io_lease_file = NULL;
+    request->io_recall_all = 1;
+
+    /* Fast path: no per-file state means no caching lease to recall. */
+    if (!state || fh_len == 0) {
+        next(request);
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        next(request);
+        return;
+    }
+
+    chimera_vfs_io_try(state, file, request);
+} /* chimera_vfs_io_recall */
+
+SYMBOL_EXPORT void
 chimera_vfs_io_lease_release(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_state      *state;
@@ -1729,7 +1793,10 @@ chimera_vfs_state_reap_idle(
         for (file = bucket->files;
              file && n < CHIMERA_VFS_STATE_REAP_BATCH;
              file = file->bucket_next) {
-            if (file->implicit_active) {
+            /* Candidates: files holding an implicit lease (reapable when idle)
+             * or with parked I/O waiters (re-pumped so an unresponsive holder
+             * is revoked at its recall deadline and the waiter makes progress). */
+            if (file->implicit_active || file->io_wait_head) {
                 file->refcount++;
                 cand[n++] = file;
             }
@@ -1738,6 +1805,7 @@ chimera_vfs_state_reap_idle(
 
         for (i = 0; i < n; i++) {
             bool reapable;
+            bool has_waiters;
 
             file = cand[i];
 
@@ -1749,10 +1817,14 @@ chimera_vfs_state_reap_idle(
             if (reapable) {
                 file->implicit_draining = 1;
             }
+            has_waiters = (file->io_wait_head != NULL);
             pthread_mutex_unlock(&file->lock);
 
             if (reapable) {
+                /* finish_drain pumps the wait queue itself. */
                 chimera_vfs_implicit_finish_drain(state, file);
+            } else if (has_waiters) {
+                chimera_vfs_state_pump_io(state, file);
             }
 
             chimera_vfs_state_put(state, file);

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -314,6 +314,20 @@ void
 chimera_vfs_io_lease_release(
     struct chimera_vfs_request *request);
 
+/* Mediate a namespace/metadata mutation (REMOVE/RENAME/LINK/SETATTR) through
+ * the lease layer: recall every caching lease on the target file identified
+ * by (fh, fh_hash) — regardless of owner, so even the operating client's own
+ * delegation is recalled (RFC 7530 §10.4.5) — then invoke next(request).  The
+ * request parks until the recall drains; no lease is held on chimera's behalf.
+ * A file with no per-file state proceeds immediately. */
+void
+chimera_vfs_io_recall(
+    struct chimera_vfs_request *request,
+    const uint8_t              *fh,
+    uint8_t                     fh_len,
+    uint64_t                    fh_hash,
+    void (                     *next )(struct chimera_vfs_request *request));
+
 /* Drop every implicit lease that has been idle (no in-flight I/O) for at
  * least `idle_ms` milliseconds.  Driven by a periodic reaper. */
 void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -11,6 +11,7 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_fh.h"
+#include "vfs/vfs_lease_types.h"
 
 struct chimera_vfs_request;
 
@@ -23,162 +24,18 @@ struct chimera_vfs_request;
  * protocols (NLM, NFSv4, SMB2) acquire and release leases through this
  * layer rather than maintaining their own per-protocol tables.
  *
+ * In addition, the VFS core itself acquires an implicit SHARE lease on
+ * behalf of actors that perform I/O without requesting a protocol lease
+ * (NFSv3, S3, NFSv4 data I/O).  That lease is held lazily — kept across
+ * operations and dropped only when it goes idle or another holder needs
+ * it — so every read/write is lease-mediated.  See vfs_lease_types.h for
+ * the shared lease vocabulary.
+ *
  * Persistence is explicitly out of scope for this pass: all state lives
  * in memory and is lost on server crash.  Reclaim handshakes (NLM grace,
  * NFSv4 CLAIM_PREVIOUS, SMB3 DH2C) work across client disconnects within
  * a single server lifetime only.
  */
-
-/* -------------------------------------------------------------------- */
-/* Lease vocabulary                                                     */
-/* -------------------------------------------------------------------- */
-
-enum chimera_vfs_lease_kind {
-    CHIMERA_VFS_LEASE_RANGE   = 0, /* byte-range lock */
-    CHIMERA_VFS_LEASE_SHARE   = 1, /* whole-file share/deny reservation */
-    CHIMERA_VFS_LEASE_CACHING = 2, /* breakable caching lease */
-    CHIMERA_VFS_LEASE_KIND_MAX
-};
-
-/* Mode bits — SMB2 RWH triple, used as the lingua franca.
- *   R = read-cache / shared range lock / SMB FILE_READ_DATA share-allow
- *   W = write-cache / exclusive range lock / SMB FILE_WRITE_DATA share-allow
- *   H = handle-cache (SMB only)
- *   D = delete (SMB FILE_SHARE_DELETE)
- *
- * RANGE leases use {R} for shared, {W} for exclusive; H and D are ignored.
- * SHARE leases use granted = access bits, denied = deny bits.
- * CACHING leases use granted directly (e.g., {R,W,H} for an SMB lease).
- */
-#define CHIMERA_VFS_LEASE_MODE_R      0x01
-#define CHIMERA_VFS_LEASE_MODE_W      0x02
-#define CHIMERA_VFS_LEASE_MODE_H      0x04
-#define CHIMERA_VFS_LEASE_MODE_D      0x08
-
-struct chimera_vfs_lease_mode {
-    uint8_t granted; /* bits the holder has been granted */
-    uint8_t denied;  /* SHARE only: bits this holder denies to others */
-};
-
-/* Protocol identifiers — used in owner.protocol so the conflict matrix
- * can apply protocol-specific same-owner coalescing rules. */
-#define CHIMERA_VFS_LEASE_PROTO_NLM   1
-#define CHIMERA_VFS_LEASE_PROTO_NFSV4 2
-#define CHIMERA_VFS_LEASE_PROTO_SMB2  3
-
-struct chimera_vfs_lease;
-
-/* Break callback — invoked synchronously by vfs_state when this lease must
- * downgrade or release.  The callback is expected to kick off the protocol-
- * specific break (build SMB2 OPLOCK_BREAK, send NFSv4 CB_RECALL) and return
- * promptly; vfs_state does not wait inside the callback.  The protocol
- * server eventually calls chimera_vfs_lease_ack() (or chimera_vfs_lease_
- * revoke() on its own timeout) to unstick the pending acquire. */
-typedef void (*chimera_vfs_lease_break_cb_t)(
-    struct chimera_vfs_lease *lease,
-    uint8_t                   needed_mode,
-    void                     *private_data);
-
-/* Liveness probe — vfs_state calls this to test whether a lease's owning
- * client/session is still considered alive.  Returns false on session
- * expiry, connection drop past grace, etc.  May be NULL (always alive). */
-typedef bool (*chimera_vfs_lease_is_alive_cb_t)(
-    const struct chimera_vfs_lease *lease,
-    void                           *private_data);
-
-/* Revocation notice — vfs_state calls this when it forcibly revokes a lease
- * (recall deadline elapsed, etc.) rather than the holder releasing it.  The
- * protocol layer uses it to mark its own state revoked (e.g. so a later use of
- * an NFSv4 delegation stateid reports NFS4ERR_DELEG_REVOKED).  May be NULL.
- * Invoked outside the file lock. */
-typedef void (*chimera_vfs_lease_revoked_cb_t)(
-    struct chimera_vfs_lease *lease,
-    void                     *private_data);
-
-struct chimera_vfs_lease_owner {
-    uint32_t                        protocol;
-    uint64_t                        client_key;
-    uint64_t                        owner_lo;
-    uint64_t                        owner_hi;
-    chimera_vfs_lease_break_cb_t    break_cb;
-    chimera_vfs_lease_is_alive_cb_t is_alive_cb;
-    chimera_vfs_lease_revoked_cb_t  revoked_cb;
-    void                           *cb_private;
-};
-
-enum chimera_vfs_break_state {
-    CHIMERA_VFS_BREAK_IDLE     = 0, /* no break in progress */
-    CHIMERA_VFS_BREAK_BREAKING = 1, /* break_cb invoked, awaiting ack */
-    CHIMERA_VFS_BREAK_ACKED    = 2, /* protocol acked, lease downgraded */
-    CHIMERA_VFS_BREAK_REVOKED  = 3, /* forcibly revoked (timeout or error) */
-};
-
-struct chimera_vfs_file_state;
-
-struct chimera_vfs_lease {
-    enum chimera_vfs_lease_kind kind;
-    struct chimera_vfs_lease_mode  mode;
-    uint64_t                       offset; /* RANGE only; SHARE/CACHING use 0 */
-    uint64_t                       length; /* RANGE only; 0 = to EOF */
-    struct chimera_vfs_lease_owner owner;
-    struct chimera_vfs_file_state *file;
-
-    enum chimera_vfs_break_state break_state;
-    uint8_t                        break_needed_mode;
-    struct timespec                break_deadline;
-
-    /* For a SHARE probe only: a caching (handle) lease held under this same
-     * key is the requester's own lease (SMB2 same-client, same lease key) and
-     * must NOT be broken when acquiring the share — the opens coalesce.  Set by
-     * the SMB server when a lease-bearing open takes its share reservation;
-     * left zero (no skip) by every other caller. */
-    uint8_t                        has_break_skip_key;
-    uint64_t                       break_skip_lo;
-    uint64_t                       break_skip_hi;
-
-    /* Intrusive linkage on the appropriate file->{range,share,caching} list. */
-    struct chimera_vfs_lease      *prev;
-    struct chimera_vfs_lease      *next;
-};
-
-/* -------------------------------------------------------------------- */
-/* Lease result enum                                                    */
-/* -------------------------------------------------------------------- */
-
-/* Conflict-test result.  Returned by chimera_vfs_state_would_conflict(),
- * chimera_vfs_state_try_insert(), and chimera_vfs_lease_test(). */
-enum chimera_vfs_lease_result {
-    CHIMERA_VFS_LEASE_GRANTED  = 0, /* no conflict; lease would be / was inserted */
-    CHIMERA_VFS_LEASE_DENIED   = 1, /* hard conflict with non-breakable holder */
-    CHIMERA_VFS_LEASE_BREAKING = 2, /* breakable holder must downgrade first */
-};
-
-/* -------------------------------------------------------------------- */
-/* Async-acquire ticket                                                 */
-/* -------------------------------------------------------------------- */
-
-/* Result of an async acquire.  GRANTED carries `granted_lease`; DENIED
- * carries `conflict` (a pointer to a conflicting holder — owned by
- * vfs_state, valid only until the callback returns). */
-typedef void (*chimera_vfs_lease_acquire_cb_t)(
-    enum chimera_vfs_lease_result result,
-    struct chimera_vfs_lease     *granted_lease,
-    struct chimera_vfs_lease     *conflict,
-    void                         *private_data);
-
-/* Caller-allocated ticket holding pending-acquire bookkeeping.  Its
- * lifetime must extend until the acquire callback fires.  Protocol
- * layers typically embed this in their existing per-lock state struct
- * (nlm_lock_entry, nfs4_state, smb_open_file's lock slot). */
-struct chimera_vfs_pending_acquire {
-    struct chimera_vfs_lease           *lease;
-    chimera_vfs_lease_acquire_cb_t      cb;
-    void                               *private_data;
-    struct chimera_vfs_file_state      *file;
-    bool                                queued;
-    struct chimera_vfs_pending_acquire *prev;
-    struct chimera_vfs_pending_acquire *next;
-};
 
 /* -------------------------------------------------------------------- */
 /* Per-file state                                                       */
@@ -196,9 +53,27 @@ struct chimera_vfs_file_state {
     struct chimera_vfs_lease           *share_resvs;
     struct chimera_vfs_lease           *caching_leases;
 
+    /* Implicit lease held by chimera itself on behalf of leaseless actors
+     * (NFSv3/S3/NFSv4 data I/O).  When active it is linked into share_resvs
+     * like any other SHARE; it is kept across operations and dropped only
+     * when idle-reaped or recalled by a conflicting holder.  Guarded by
+     * file->lock.  See chimera_vfs_io_lease_acquire(). */
+    struct chimera_vfs_lease            implicit_lease;
+    uint8_t                             implicit_active;    /* linked in share_resvs */
+    uint8_t                             implicit_draining;  /* recall in progress */
+    uint32_t                            implicit_inflight;  /* in-flight ops pinning it */
+    struct timespec                     implicit_last_used; /* CLOCK_MONOTONIC */
+
     /* FIFO queue of acquires waiting on a break to complete. */
     struct chimera_vfs_pending_acquire *pending_head;
     struct chimera_vfs_pending_acquire *pending_tail;
+
+    /* FIFO queue of I/O requests waiting for the implicit lease to become
+     * grantable (a conflicting holder is mid-recall, or a prior recall of
+     * our own implicit lease is still draining).  Distinct from the
+     * pending queue above, which carries protocol-lease acquires. */
+    struct chimera_vfs_pending_acquire *io_wait_head;
+    struct chimera_vfs_pending_acquire *io_wait_tail;
 
     /* Back-pointer set on creation so ack/revoke/remove can pump the
      * pending queue without changing public-API signatures. */
@@ -218,6 +93,9 @@ struct chimera_vfs_state {
     /* Default deadline applied by chimera_vfs_lease_begin_break() when the
      * caller passes 0.  Matches SMB2 lease-break timeout convention. */
     uint32_t                        default_break_deadline_ms;
+    /* Implicit leases held this long without any I/O are dropped by
+     * chimera_vfs_state_reap_idle(). */
+    uint32_t                        implicit_idle_ms;
 };
 
 /* -------------------------------------------------------------------- */
@@ -408,16 +286,44 @@ chimera_vfs_state_break_caching(
     uint64_t                  fh_hash);
 
 /* -------------------------------------------------------------------- */
-/* I/O hook                                                             */
+/* Implicit I/O lease (held by chimera on behalf of leaseless actors)   */
 /* -------------------------------------------------------------------- */
 
-/* Called by VFS core before dispatching a READ or WRITE request.  In
- * Stage A this is a no-op pass-through that always returns 0 (success);
- * Stage B+ will enforce range-lock conflicts and break caching leases.
- * Returns 0 on permit, a CHIMERA_VFS_E* error code on deny. */
-int
-chimera_vfs_state_check_io(
+/* Mediate request through the lease layer, then invoke next(request) to
+ * proceed to dispatch.  Direction is taken from request->opcode (READ =>
+ * read access, WRITE/metadata-mutation => write access).
+ *
+ * If `owner` is non-NULL the I/O is attributed to that owner (a lease-
+ * holding client, so its own delegation/oplock is not self-recalled);
+ * otherwise chimera acquires/holds an internal implicit SHARE on the
+ * file's behalf.  Either way, conflicting holders are recalled and the
+ * request waits (parks) until every break acks/revokes, after which
+ * next(request) is invoked.  A failure (e.g. mandatory byte-range
+ * conflict) sets request->status and invokes request->complete instead
+ * of next. */
+void
+chimera_vfs_io_lease_acquire(
+    struct chimera_vfs_request           *request,
+    const struct chimera_vfs_lease_owner *owner,
+    void (                               *next )(struct chimera_vfs_request *request));
+
+/* Release the in-flight pin taken by chimera_vfs_io_lease_acquire().  Safe
+ * to call when no implicit lease was taken (fast path).  Must be called
+ * exactly once per acquire, from the operation's completion path. */
+void
+chimera_vfs_io_lease_release(
     struct chimera_vfs_request *request);
+
+/* Drop every implicit lease that has been idle (no in-flight I/O) for at
+ * least `idle_ms` milliseconds.  Driven by a periodic reaper. */
+void
+chimera_vfs_state_reap_idle(
+    struct chimera_vfs_state *state,
+    uint64_t                  idle_ms);
+
+/* -------------------------------------------------------------------- */
+/* Break-on-write                                                       */
+/* -------------------------------------------------------------------- */
 
 /* Break (to NONE) every read-caching lease invalidated by a write to the
  * file identified by (fh, fh_hash), except the writer's own write-caching

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -314,6 +314,13 @@ void
 chimera_vfs_io_lease_release(
     struct chimera_vfs_request *request);
 
+/* Resume a parked I/O/metadata request on its owning thread.  Called by the
+ * VFS thread's doorbell handler when draining pending_io_resume (the lease
+ * pump marshals parked requests here via chimera_vfs_io_resume_post). */
+void
+chimera_vfs_state_io_resume(
+    struct chimera_vfs_request *request);
+
 /* Mediate a namespace/metadata mutation (REMOVE/RENAME/LINK/SETATTR) through
  * the lease layer: recall every caching lease on the target file identified
  * by (fh, fh_hash) — regardless of owner, so even the operating client's own


### PR DESCRIPTION
## Context

Chimera's unified lease layer (`src/vfs/vfs_state.{h,c}`) — RANGE / SHARE / CACHING leases expressing NLM byte-range locks, SMB share modes, SMB oplocks/leases, and NFSv4 delegations — was only ever driven by clients that *explicitly* requested protocol leases. When an actor performed I/O **without** lease intent, the codebase relied on a hodgepodge of ad-hoc break calls scattered across the protocol servers (SMB `break_on_write`, NFSv4 `break_caching` with `NFS4ERR_DELAY`), with real gaps: NFSv4 data WRITE recalled nothing, and SMB remove/rename, all NFSv3 ops, and all S3 ops recalled nothing.

This makes **all** read/write/metadata activity lease-mediated: either a NAS client holds the lease, or **chimera holds an implicit lease on the actor's behalf**. An NFSv3 write now means the server holds a write lease while it writes, exactly as an NFSv4 client would hold a delegation.

## Model

Chimera's implicit lease is a *real, cached, lazily-released, breakable* deny-nothing SHARE under a new internal owner (`CHIMERA_VFS_LEASE_PROTO_INTERNAL`). It is acquired on first I/O, held across operations, and dropped only when it goes idle (reaped by the close-thread timer) or another holder recalls it — making chimera a first-class holder in its own lease layer, symmetric with NAS clients and forward-compatible with pushing leases into the backend. Conflicting holders are recalled and the I/O waits for the breaks to complete before proceeding.

deny=0 SHARE is the right shape: two independent leaseless writers never serialize, yet a write-share still recalls another client's conflicting delegation/oplock, and a real client open can recall the implicit lease in turn. The conflict matrix was extended so a *breakable* SHARE holder is recalled (BREAKING) rather than hard-denied.

## What's included

- **Phase 1** — VFS core acquires/holds the implicit lease for `read`/`write`; `chimera_vfs_read/write` keep their signatures (NULL owner → implicit lease), with new `_owned` variants carrying the actor's owner. SMB read/write pass the SMB owner (dropping the inline `break_on_write`); NFSv4 open-state read/write pass `{NFSV4, client_id, fh_hash}`, closing the NFSv4 data-WRITE coherency gap without self-recall.
- **Phase 2** — `chimera_vfs_io_recall()` recalls every caching lease on the target file for namespace/metadata mutations (`setattr`/`remove_at`/`rename_at`/`link_at`), so SMB, NFSv3 and S3 now invalidate conflicting delegations/oplocks, not just NFSv4.
- Lease vocabulary split into `vfs_lease_types.h` to break the `vfs.h` ↔ `vfs_state.h` include cycle.
- Idle reaper bounds resident per-file state; parked-request resumes are marshaled to the owning thread so dispatch and reply run where the connection's iovecs live (fixing a cross-thread iovec abort on the delegation-recall path), and metadata recall breaks SMB leases fully to NONE / re-arms ACKED holders (fixing an SMB metadata-recall livelock).

## Validation

Full `make check` passes end-to-end: `test_release` and `test_debug` (ASan) each 9742/9742 including the KVM NFS/SMB suites and pynfs delegation tests, `build_clang` (scan-build) reports no bugs, and reuse-lint/copyright pass.