### PR TITLE
nfs4: bound attrmask response write (heap overflow from SETATTR/CREATE/OPEN)

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -205,9 +205,20 @@ chimera_nfs4_mask2attr(
 {
     int max_word_used = 0;
 
-    memset(rsp_mask, 0, sizeof(uint32_t) * num_req_mask);
+    /*
+     * num_req_mask is the client-supplied request bitmap length and is
+     * unbounded (the XDR decoder does not cap it).  This routine only ever
+     * reports attributes that live in bitmap words 0 and 1, and every caller
+     * allocates a 4-word response buffer, so clear exactly the two words we may
+     * write rather than sizing the memset by num_req_mask -- the latter is a
+     * heap overflow of rsp_mask (e.g. SETATTR with num_attrmask=100 would zero
+     * 400 bytes into a 16-byte allocation).  Likewise, only index req_mask
+     * within its declared length: reads of word 1 require num_req_mask >= 2.
+     */
+    rsp_mask[0] = 0;
+    rsp_mask[1] = 0;
 
-    if (num_req_mask >= 1 &&
+    if (num_req_mask >= 2 &&
         (req_mask[1] & (1 << (FATTR4_MODE - 32))) &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
         rsp_mask[1]  |= (1 << (FATTR4_MODE - 32));


### PR DESCRIPTION
## Summary

`chimera_nfs4_mask2attr()` zeroed the response bitmap with `memset(rsp_mask, 0, sizeof(uint32_t) * num_req_mask)`, where `num_req_mask` is the **client-supplied** request bitmap length and is not capped by the XDR decoder. The callers (SETATTR, CREATE, OPEN) allocate a **4-word** response buffer, so a request with e.g. `num_attrmask=100` zeroes 400 bytes into a 16-byte allocation — a heap out-of-bounds write driven directly by wire input.

## Fix

The routine only ever reports attributes in bitmap words 0 and 1, so clear exactly those two words instead of sizing the memset by `num_req_mask`. Also fixes an out-of-bounds **read**: the `FATTR4_MODE` branch reads `req_mask[1]` but was guarded by `num_req_mask >= 1`; reads of word 1 require `>= 2`.

No behaviour change for well-formed requests — pynfs `combined_memfs_nfs4.0/4.1` (which exercises SETATTR/CREATE/OPEN) passes under the ASan debug build.

Part of a security review of the protocol-facing parsers.